### PR TITLE
fix(clean): give each input its own output path

### DIFF
--- a/src/vid_cleaner/cli/clean_video.py
+++ b/src/vid_cleaner/cli/clean_video.py
@@ -6,7 +6,12 @@ import cappa
 from nclutils import pp
 
 from vid_cleaner import settings
-from vid_cleaner.utils import coerce_video_files, copy_to_output, render_substeps
+from vid_cleaner.utils import (
+    coerce_video_files,
+    copy_to_output,
+    render_substeps,
+    resolve_out_path_override,
+)
 from vid_cleaner.vidcleaner import CleanCommand
 
 from vid_cleaner.models.video_file import VideoFile  # isort: skip
@@ -76,8 +81,10 @@ def main(clean_cmd: CleanCommand) -> None:
         pp.error("Cannot convert to both H265 and VP9")
         raise cappa.Exit(code=1)
 
+    out_path_override = resolve_out_path_override(clean_cmd.files)
+
     for video in coerce_video_files(clean_cmd.files):
-        settings.out_path = settings.out_path or video.path
+        settings.out_path = out_path_override or video.path
 
         video_file = video
 

--- a/src/vid_cleaner/cli/clip_video.py
+++ b/src/vid_cleaner/cli/clip_video.py
@@ -7,7 +7,12 @@ import cappa
 from nclutils import pp
 
 from vid_cleaner import settings
-from vid_cleaner.utils import coerce_video_files, copy_to_output, render_substeps
+from vid_cleaner.utils import (
+    coerce_video_files,
+    copy_to_output,
+    render_substeps,
+    resolve_out_path_override,
+)
 from vid_cleaner.vidcleaner import ClipCommand
 
 
@@ -33,8 +38,10 @@ def main(clip_cmd: ClipCommand) -> None:
         pp.error("`--duration` must be in format HH:MM:SS")
         raise cappa.Exit(code=1)
 
+    out_path_override = resolve_out_path_override(clip_cmd.files)
+
     for video in coerce_video_files(clip_cmd.files):
-        settings.out_path = settings.out_path or video.path
+        settings.out_path = out_path_override or video.path
 
         # Print the video name first so live progress bars render beneath it, then collect each
         # operation's outcome and render the result tree once the file is done. The render runs in

--- a/src/vid_cleaner/utils/__init__.py
+++ b/src/vid_cleaner/utils/__init__.py
@@ -9,6 +9,7 @@ from .cli import (  # isort: skip
     copy_to_output,
     create_default_config,
     parse_trait_filters,
+    resolve_out_path_override,
 )
 
 __all__ = [
@@ -22,5 +23,6 @@ __all__ = [
     "query_sonarr",
     "query_tmdb",
     "render_substeps",
+    "resolve_out_path_override",
     "run_ffprobe",
 ]

--- a/src/vid_cleaner/utils/cli.py
+++ b/src/vid_cleaner/utils/cli.py
@@ -7,6 +7,7 @@ import cappa
 from nclutils import pp
 from nclutils.fs import backup_path, copy_file
 
+from vid_cleaner import settings
 from vid_cleaner.constants import (
     DEFAULT_CONFIG_PATH,
     SYMBOL_CHECK,
@@ -43,6 +44,27 @@ def coerce_video_files(files: list[Path]) -> list[VideoFile]:
             raise cappa.Exit(msg, code=1)
 
     return [VideoFile(path.expanduser().resolve().absolute()) for path in files]
+
+
+def resolve_out_path_override(files: list[Path]) -> Path | None:
+    """Capture the explicit `--out` override before per-file processing mutates it.
+
+    Read `settings.out_path` once up front so the first file's resolved path can't leak into later files and overwrite them all with the first file's name. Reject a single `--out` paired with multiple inputs, since one path cannot name many outputs.
+
+    Args:
+        files (list[Path]): The input files the command will process.
+
+    Returns:
+        Path | None: The user's explicit `--out` value, or None when not set.
+
+    Raises:
+        cappa.Exit: If `--out` is combined with more than one input file.
+    """
+    override = settings.out_path
+    if override and len(files) > 1:
+        pp.error("`--out` cannot be used with multiple input files")
+        raise cappa.Exit(code=1)
+    return override
 
 
 def copy_to_output(src: Path, dst: Path, *, overwrite: bool) -> tuple[Path, list[str]]:

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -23,6 +23,7 @@ def set_default_settings(tmp_path, mocker):
         {
             "cache_dir": cache_dir,
             "langs_to_keep": ["en"],
+            "out_path": None,
             "downmix_stereo": False,
             "keep_local_subtitles": False,
             "keep_commentary": False,
@@ -49,6 +50,25 @@ def test_fail_on_flag_conflict(debug, tmp_path, capsys, mock_video_path) -> None
 
     assert exc_info.value.code == 1
     assert "Cannot convert to both H265 and VP9" in output
+
+
+def test_clean_out_with_multiple_files_errors(debug, tmp_path, capsys) -> None:
+    """Verify clean command rejects --out when given more than one input file."""
+    # Given: an explicit --out alongside two input files
+    first = Path(tmp_path / "first_video.mkv")
+    first.touch()
+    second = Path(tmp_path / "second_video.mkv")
+    second.touch()
+    args = ["clean", "-vv", "--out", str(tmp_path / "out.mkv"), str(first), str(second)]
+
+    # When: running clean with --out and multiple files
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: the command exits with an error explaining the conflict
+    output = capsys.readouterr().err
+    assert exc_info.value.code == 1
+    assert "`--out` cannot be used with multiple input files" in output
 
 
 @pytest.mark.parametrize(
@@ -460,6 +480,78 @@ def test_save_each_step(
     assert "✔ Process file (downmix to stereo, drop unwanted subtitles)" in output
     assert "✔ Convert to H.265" in output
     assert "cleaned_video.mkv" in output
+
+
+def test_clean_multiple_files_use_distinct_output_paths(
+    mocker,
+    mock_ffprobe_box,
+    mock_ffmpeg,
+    capsys,
+    tmp_path,
+) -> None:
+    """Verify each input file is written to its own output path, not the first file's."""
+    # Given: two distinct input files
+    first = Path(tmp_path / "first_video.mkv")
+    first.touch()
+    second = Path(tmp_path / "second_video.mkv")
+    second.touch()
+
+    args = ["clean", "-vv", "--downmix", str(first), str(second)]
+
+    # And: mocked external dependencies; copy_file echoes the destination it was handed
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("reference.json"),
+    )
+    mock_copy = mocker.patch("vid_cleaner.utils.cli.copy_file", side_effect=lambda *, dst, **_: dst)
+    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+
+    # When: cleaning both files in a single invocation
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: each file is copied to its own destination, not both to the first file's path
+    assert exc_info.value.code == 0
+    destinations = [call.kwargs["dst"] for call in mock_copy.mock_calls]
+    assert destinations == [first.resolve(), second.resolve()]
+
+
+def test_clean_multiple_files_overwrite_each_in_place(
+    mocker,
+    mock_ffprobe_box,
+    mock_ffmpeg,
+    capsys,
+    tmp_path,
+) -> None:
+    """Verify each file overwrites itself with --overwrite, leaving no original deleted."""
+    # Given: two distinct input files
+    first = Path(tmp_path / "first_video.mkv")
+    first.touch()
+    second = Path(tmp_path / "second_video.mkv")
+    second.touch()
+
+    args = ["clean", "-vv", "--overwrite", "--downmix", str(first), str(second)]
+
+    # And: mocked external dependencies; copy_file echoes the destination it was handed
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("reference.json"),
+    )
+    mock_copy = mocker.patch("vid_cleaner.utils.cli.copy_file", side_effect=lambda *, dst, **_: dst)
+    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+
+    # When: cleaning both files in place
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: each file overwrites itself and neither original is deleted
+    assert exc_info.value.code == 0
+    destinations = [call.kwargs["dst"] for call in mock_copy.mock_calls]
+    assert destinations == [first.resolve(), second.resolve()]
+    assert first.exists()
+    assert second.exists()
 
 
 def test_clean_renders_completed_steps_on_error(


### PR DESCRIPTION
## Summary

Running `vid-cleaner clean --downmix --1080p *.mkv` (or any multi-file invocation) wrote **every** file to the **first** file's output path, so outputs overwrote each other. With `--overwrite`, it was worse than an overwrite: each later file's content was copied onto the first file, then the original was deleted, causing silent data loss.

## Root cause

The per-file output path was stashed in the global `settings.out_path` and read back on the next iteration:

```python
for video in coerce_video_files(clean_cmd.files):
    settings.out_path = settings.out_path or video.path
```

On the first file `out_path` is `None` → becomes file #1's path. On every later file it's already truthy, so `or video.path` short-circuits and keeps file #1's path.

## Fix

- Capture the explicit `--out` override **once before the loop** and recompute each file's default from that override, via a shared `resolve_out_path_override()` helper in `utils/cli.py` (used by both `clean` and `clip`).
- Reject `--out` combined with multiple input files, since a single path cannot name many outputs.

## Behavior

| Invocation | Result |
|---|---|
| `clean *.mkv` | each file cleaned to its own path |
| `clean --overwrite *.mkv` | each file overwrites itself; no originals deleted |
| `clean --out a.mkv one.mkv` | writes to `a.mkv` |
| `clean --out a.mkv *.mkv` | errors: `--out` cannot be used with multiple input files |

## Tests

Added regression coverage for distinct per-file output paths, in-place `--overwrite`, and the `--out` + multiple-files guard. Full suite: 50 passed.