### PR TITLE
fix(clean): write output atomically to protect the original file

### DIFF
--- a/src/vid_cleaner/utils/cli.py
+++ b/src/vid_cleaner/utils/cli.py
@@ -90,8 +90,10 @@ def copy_to_output(src: Path, dst: Path, *, overwrite: bool) -> tuple[Path, list
 
     # Stage beside dst (same filesystem) so the final swap is an atomic rename.
     # copy_file verifies the copied size, so a short or failed copy raises here,
-    # before the original is ever touched.
-    staged = dst.with_name(f".{dst.name}.vidcleaner-tmp-{uuid.uuid4().hex}")
+    # before the original is ever touched. Keep the temp name a fixed length
+    # (not dst.name + suffix) so a long-but-valid destination name can't push
+    # the staged path past the filesystem's 255-byte component limit.
+    staged = dst.with_name(f".vidcleaner-tmp-{uuid.uuid4().hex}{dst.suffix}")
     backup: Path | None = None
     try:
         copy_file(

--- a/src/vid_cleaner/utils/cli.py
+++ b/src/vid_cleaner/utils/cli.py
@@ -1,11 +1,13 @@
 """Utilities for CLI."""
 
 import shutil
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 import cappa
 from nclutils import pp
-from nclutils.fs import backup_path, copy_file
+from nclutils.fs import copy_file
 
 from vid_cleaner import settings
 from vid_cleaner.constants import (
@@ -68,9 +70,11 @@ def resolve_out_path_override(files: list[Path]) -> Path | None:
 
 
 def copy_to_output(src: Path, dst: Path, *, overwrite: bool) -> tuple[Path, list[str]]:
-    """Copy a processed file to its destination, backing up any existing file first.
+    """Copy a processed file to its destination via an atomic same-filesystem rename.
 
-    Own the backup explicitly rather than letting ``copy_file`` make a silent one, so the backup's location can be reported back to the user.
+    Stage the copy beside ``dst`` and swap it into place with ``Path.replace`` so a
+    crash or I/O error mid-copy leaves the original intact rather than truncated. Own
+    the backup explicitly so its location can be reported back to the user.
 
     Args:
         src (Path): The processed temporary file to copy.
@@ -84,22 +88,35 @@ def copy_to_output(src: Path, dst: Path, *, overwrite: bool) -> tuple[Path, list
     dst = dst.expanduser().resolve()
     messages: list[str] = []
 
-    if not overwrite and dst.exists():
-        backup = backup_path(dst, with_progress=True, transient=True, console=pp.console())
-        if backup:
+    # Stage beside dst (same filesystem) so the final swap is an atomic rename.
+    # copy_file verifies the copied size, so a short or failed copy raises here,
+    # before the original is ever touched.
+    staged = dst.with_name(f".{dst.name}.vidcleaner-tmp-{uuid.uuid4().hex}")
+    try:
+        copy_file(
+            src=src,
+            dst=staged,
+            keep_backup=False,
+            with_progress=True,
+            transient=True,
+            console=pp.console(),
+        )
+
+        # Move (not copy) the original aside so peak destination disk stays at 2x,
+        # then free the slot for the atomic swap below.
+        if dst.exists() and not overwrite:
+            stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+            backup = dst.with_name(f"{dst.name}.{stamp}-{uuid.uuid4().hex[:8]}.bak")
+            dst.replace(backup)
             messages.append(f"{SYMBOL_CHECK} Backed up original to {backup}")
 
-    out_file = copy_file(
-        src=src,
-        dst=dst,
-        keep_backup=False,  # already handled above so the backup path can be surfaced
-        with_progress=True,
-        transient=True,
-        console=pp.console(),
-    )
-    messages.append(f"{SYMBOL_CHECK} Saved to {out_file}")
+        staged.replace(dst)  # atomic within the destination filesystem
+    finally:
+        # No-op on success (staged was renamed away); removes the partial temp on failure.
+        staged.unlink(missing_ok=True)
 
-    return out_file, messages
+    messages.append(f"{SYMBOL_CHECK} Saved to {dst}")
+    return dst, messages
 
 
 def create_default_config() -> None:

--- a/src/vid_cleaner/utils/cli.py
+++ b/src/vid_cleaner/utils/cli.py
@@ -92,6 +92,7 @@ def copy_to_output(src: Path, dst: Path, *, overwrite: bool) -> tuple[Path, list
     # copy_file verifies the copied size, so a short or failed copy raises here,
     # before the original is ever touched.
     staged = dst.with_name(f".{dst.name}.vidcleaner-tmp-{uuid.uuid4().hex}")
+    backup: Path | None = None
     try:
         copy_file(
             src=src,
@@ -110,7 +111,15 @@ def copy_to_output(src: Path, dst: Path, *, overwrite: bool) -> tuple[Path, list
             dst.replace(backup)
             messages.append(f"{SYMBOL_CHECK} Backed up original to {backup}")
 
-        staged.replace(dst)  # atomic within the destination filesystem
+        try:
+            staged.replace(dst)  # atomic within the destination filesystem
+        except OSError:
+            # A same-filesystem rename failing here is near-impossible, but if it does
+            # after the original was moved aside, put the original back at its expected
+            # path rather than stranding it under the .bak name.
+            if backup is not None:
+                backup.replace(dst)
+            raise
     finally:
         # No-op on success (staged was renamed away); removes the partial temp on failure.
         staged.unlink(missing_ok=True)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -138,8 +138,10 @@ def test_stream_processing(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Running clean command
@@ -205,8 +207,10 @@ def test_clean_video_foreign_language(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("fr")])
 
     # When: Processing the video file
@@ -266,8 +270,10 @@ def test_clean_video_downmix(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("no_stereo.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Processing the video file
@@ -305,8 +311,10 @@ def test_clean_video_downmix_stereo_commentary_kept(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("commentary_no_lang.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Processing the video file with downmix requested
@@ -343,8 +351,10 @@ def test_clean_video_downmix_unmapped_channel_count(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("unmapped_channels.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Processing the video file with downmix requested
@@ -372,8 +382,10 @@ def test_clean_video_downmix_dialogue_forward_filter(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("no_stereo.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Processing the video file with downmix requested
@@ -405,8 +417,10 @@ def test_clean_video_downmix_atmos(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("atmos_no_stereo.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Processing the video file with downmix requested
@@ -440,8 +454,10 @@ def test_clean_video_downmix_does_not_clobber_kept_stream(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("no_stereo.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Processing the video file with downmix requested
@@ -492,8 +508,10 @@ def test_clean_reorganize_streams(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("wrong_order.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Processing the video file
@@ -555,8 +573,10 @@ def test_convert_video(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
     mocker.patch.object(TempFile, "new_tmp_path", return_value=(mock_video_path))
     mocker.patch.object(TempFile, "latest_temp_path", return_value=(mock_video_path))
@@ -612,10 +632,12 @@ def test_save_each_step(
         return_value=mock_ffprobe_box("reference.json"),
     )
     mocker.patch(
-        "vid_cleaner.utils.cli.copy_file",
-        side_effect=[mock_video_path_1, "cleaned_video.mkv"],
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=[
+            (mock_video_path_1, ["✔ Saved to intermediate"]),
+            (Path("cleaned_video.mkv"), ["✔ Saved to cleaned_video.mkv"]),
+        ],
     )
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
     mocker.patch.object(TempFile, "new_tmp_path", return_value=(mock_video_path))
     mocker.patch.object(TempFile, "latest_temp_path", return_value=(mock_video_path))
@@ -672,8 +694,10 @@ def test_clean_multiple_files_use_distinct_output_paths(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
     )
-    mock_copy = mocker.patch("vid_cleaner.utils.cli.copy_file", side_effect=lambda *, dst, **_: dst)
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mock_copy = mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, [f"✔ Saved to {dst}"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: cleaning both files in a single invocation
@@ -682,7 +706,7 @@ def test_clean_multiple_files_use_distinct_output_paths(
 
     # Then: each file is copied to its own destination, not both to the first file's path
     assert exc_info.value.code == 0
-    destinations = [call.kwargs["dst"] for call in mock_copy.mock_calls]
+    destinations = [call.args[1] for call in mock_copy.mock_calls]
     assert destinations == [first.resolve(), second.resolve()]
 
 
@@ -707,8 +731,10 @@ def test_clean_multiple_files_overwrite_each_in_place(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
     )
-    mock_copy = mocker.patch("vid_cleaner.utils.cli.copy_file", side_effect=lambda *, dst, **_: dst)
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mock_copy = mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, [f"✔ Saved to {dst}"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: cleaning both files in place
@@ -717,7 +743,7 @@ def test_clean_multiple_files_overwrite_each_in_place(
 
     # Then: each file overwrites itself and neither original is deleted
     assert exc_info.value.code == 0
-    destinations = [call.kwargs["dst"] for call in mock_copy.mock_calls]
+    destinations = [call.args[1] for call in mock_copy.mock_calls]
     assert destinations == [first.resolve(), second.resolve()]
     assert first.exists()
     assert second.exists()
@@ -766,8 +792,10 @@ def test_clean_video_downmix_skip_when_stereo_exists(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Processing with downmix requested but not forced
@@ -801,8 +829,10 @@ def test_clean_video_downmix_force_recreates_stereo(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Processing with downmix forced
@@ -839,8 +869,10 @@ def test_clean_video_downmix_force_recreates_from_multiple_stereo(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("two_stereo_and_surround.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Forcing downmix with two stereo tracks present
@@ -876,8 +908,10 @@ def test_clean_video_downmix_force_no_surround_keeps_stereo(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("stereo_no_surround.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Forcing downmix with no surround source to rebuild from
@@ -907,8 +941,10 @@ def test_clean_video_downmix_force_noop_without_existing_stereo(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("no_stereo.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="cleaned_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
     mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
 
     # When: Forcing downmix with no existing stereo mix

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,6 +128,36 @@ def test_copy_to_output_creates_new_destination(tmp_path: Path, *, overwrite: bo
     assert any("Saved to" in m for m in messages)
 
 
+def test_copy_to_output_restores_original_when_swap_fails(tmp_path: Path, mocker) -> None:
+    """Verify a failed final swap restores the original to its path instead of stranding it."""
+    # Given: an existing destination and source, with the atomic swap (but not the backup
+    #        move) set to fail, mimicking a rename failure after the original was moved aside
+    src = tmp_path / "processed.mkv"
+    src.write_text("new content")
+    dst = tmp_path / "movie.mkv"
+    dst.write_text("original content")
+
+    real_replace = Path.replace
+
+    def _fail_swap(self: Path, target: Path) -> Path:
+        # Only the staged temp -> dst swap fails; the dst -> .bak move and the
+        # .bak -> dst restore both run for real.
+        if "vidcleaner-tmp" in self.name:
+            raise OSError(5, "Input/output error")
+        return real_replace(self, target)
+
+    mocker.patch.object(Path, "replace", autospec=True, side_effect=_fail_swap)
+
+    # When: the swap fails after the backup move
+    with pytest.raises(OSError, match="Input/output error"):
+        copy_to_output(src, dst, overwrite=False)
+
+    # Then: the original is back at its expected path, with nothing stranded
+    assert dst.read_text() == "original content"
+    assert list(tmp_path.glob("*.bak")) == []
+    assert list(tmp_path.glob(".*vidcleaner-tmp*")) == []
+
+
 def test_copy_to_output_overwrite_does_not_mutate_hardlink(tmp_path: Path) -> None:
     """Verify overwriting replaces the inode so existing hardlinks keep the original content."""
     # Given: a destination with a hardlink sharing its inode (as *arr apps / seeding create)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,3 +67,80 @@ def test_copy_to_output_overwrite_skips_backup(tmp_path: Path) -> None:
     assert out_file.read_text() == "new content"
     assert all("Backed up" not in m for m in messages)
     assert any("Saved to" in m for m in messages)
+
+
+def test_copy_to_output_preserves_original_when_staging_fails(tmp_path: Path, mocker) -> None:
+    """Verify a staging failure leaves the original intact with no backup or temp file."""
+    # Given: an existing destination and a source, with the staging copy set to fail
+    #        after partially writing (mimicking a real mid-copy I/O error)
+    src = tmp_path / "processed.mkv"
+    src.write_text("new content")
+    dst = tmp_path / "movie.mkv"
+    dst.write_text("original content")
+
+    def _fail_mid_copy(*, src, dst, **kwargs):
+        Path(dst).write_text("corrupt partial")
+        raise OSError(5, "Input/output error")
+
+    mocker.patch("vid_cleaner.utils.cli.copy_file", autospec=True, side_effect=_fail_mid_copy)
+
+    # When: the staging copy fails
+    with pytest.raises(OSError, match="Input/output error"):
+        copy_to_output(src, dst, overwrite=True)
+
+    # Then: the original is byte-for-byte intact and nothing is left behind
+    assert dst.read_text() == "original content"
+    assert list(tmp_path.glob("*.bak")) == []
+    assert list(tmp_path.glob(".*vidcleaner-tmp*")) == []
+
+
+@pytest.mark.parametrize("overwrite", [True, False])
+def test_copy_to_output_leaves_no_temp_file_on_success(tmp_path: Path, *, overwrite: bool) -> None:
+    """Verify a successful write leaves no staging temp file behind in either mode."""
+    # Given: a processed source and an existing destination
+    src = tmp_path / "processed.mkv"
+    src.write_text("new content")
+    dst = tmp_path / "movie.mkv"
+    dst.write_text("original content")
+
+    # When: copying to the destination
+    copy_to_output(src, dst, overwrite=overwrite)
+
+    # Then: the content is written and no staging temp remains
+    assert dst.read_text() == "new content"
+    assert list(tmp_path.glob(".*vidcleaner-tmp*")) == []
+
+
+@pytest.mark.parametrize("overwrite", [True, False])
+def test_copy_to_output_creates_new_destination(tmp_path: Path, *, overwrite: bool) -> None:
+    """Verify copying to a non-existent destination creates it in both modes."""
+    # Given: a processed source and a destination that does not exist yet
+    src = tmp_path / "processed.mkv"
+    src.write_text("new content")
+    dst = tmp_path / "movie.mkv"
+
+    # When: copying to the missing destination
+    out_file, messages = copy_to_output(src, dst, overwrite=overwrite)
+
+    # Then: the destination is created with no backup and the save is reported
+    assert out_file.read_text() == "new content"
+    assert list(tmp_path.glob("*.bak")) == []
+    assert any("Saved to" in m for m in messages)
+
+
+def test_copy_to_output_overwrite_does_not_mutate_hardlink(tmp_path: Path) -> None:
+    """Verify overwriting replaces the inode so existing hardlinks keep the original content."""
+    # Given: a destination with a hardlink sharing its inode (as *arr apps / seeding create)
+    src = tmp_path / "processed.mkv"
+    src.write_text("new content")
+    dst = tmp_path / "movie.mkv"
+    dst.write_text("original content")
+    link = tmp_path / "seed.mkv"
+    link.hardlink_to(dst)
+
+    # When: overwriting the destination
+    copy_to_output(src, dst, overwrite=True)
+
+    # Then: the destination has the new content but the hardlink keeps the original
+    assert dst.read_text() == "new content"
+    assert link.read_text() == "original content"

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -63,8 +63,10 @@ def test_clipping_video(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="clipped_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clip_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to clipped_video.mkv"]),
+    )
 
     # When: Running clip command
     with pytest.raises(cappa.Exit) as exc_info:
@@ -113,8 +115,10 @@ def test_clipping_video_dryrun(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
     )
-    mocker.patch("vid_cleaner.utils.cli.copy_file", return_value="clipped_video.mkv")
-    mocker.patch("vid_cleaner.utils.cli.backup_path", return_value=None)
+    mocker.patch(
+        "vid_cleaner.cli.clip_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to clipped_video.mkv"]),
+    )
 
     # When: Running clip command in dry-run mode
     with pytest.raises(cappa.Exit) as exc_info:


### PR DESCRIPTION
## Summary

Rewrites the final write-back of a processed video (`copy_to_output`) to be crash-safe. The processed file is copied to a hidden temporary file beside the destination and then swapped into place with an atomic same-filesystem rename, so an I/O error or interruption mid-copy can no longer truncate or partially overwrite the original.

## Changes

- Stage the copy to a fixed-length hidden temp (`.vidcleaner-tmp-<uuid>`) in the destination directory, then move it into place with `Path.replace` (atomic within one filesystem). The destination is never opened for writing until a complete, size-verified copy exists.
- In non-overwrite mode, move (rather than copy) the existing destination aside to a timestamped `.bak` before the swap; keep the `--overwrite` path free of a backup.
- On a staging failure, remove the partial temp and leave the original untouched; if the final rename fails after the original was moved aside, restore the original from the `.bak` to its expected path before re-raising.
- Derive the staging temp name from a uuid and the file suffix only, so a long destination filename can't push the temp path past the 255-byte filename limit.
- Migrate the `clean`/`clip` command tests to mock `copy_to_output` at its call-site boundary, and add `copy_to_output` unit tests covering staging failure, swap-failure restore, the no-leftover-temp guarantee, hardlink preservation, and new-destination creation.
