### PR TITLE
feat(language): find original language from filenames and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tools to transcode, inspect and convert videos. This package provides convenienc
 
 -   Remove commentary tracks and subtitles
 -   Remove unwanted audio and subtitle tracks
--   Integrate with TMDb and Radarr/Sonarr to determine languages of videos
+-   Determine a video's original language from its filename, its container metadata, or the TMDb, Radarr, and Sonarr APIs
 -   Convert to H.265 or VP9
 -   Convert 4k to 1080p
 -   Downmix any surround layout (5.1, 7.1, and Atmos above 7.1) into a stereo track when one is missing, or recreate an existing stereo track with `--force`, using a dialogue-forward filter that keeps speech clear
@@ -44,7 +44,13 @@ Defaults for vid-cleaner are set in the configuration file located at `~/.config
 
 If you've updated your user config file, the flags for the cli will work in reverse order. For example, if you've set `downmix_stereo = true` in your user config file, the flag `--downmix` will actually disable downmixing.
 
-**Important:** Vid-cleaner makes decisions about which audio and subtitle tracks to keep based on the original language of the video. This is determined by querying the TMDb, Radarr, andSonarr APIs. To use this functionality, you must add the appropriate API keys to the configuration file.
+**Important:** Vid-cleaner makes decisions about which audio and subtitle tracks to keep based on the original language of the video. To find that language, it looks for an IMDb or TMDB id in three places, stopping at the first one that resolves:
+
+1. The filename, matching either a bare `tt0245712` or the `{tmdb-55}` naming convention.
+2. The container's own `IMDB` and `TMDB` metadata tags, as written by tools like mkvmerge.
+3. A Radarr or Sonarr title search.
+
+The first two need only `tmdb_api_key` in the configuration file. Set the `radarr_` and `sonarr_` keys if you want the title search as a fallback.
 
 ```toml
 # Languages to keep (list of ISO 639-1 codes)

--- a/src/vid_cleaner/models/video_file.py
+++ b/src/vid_cleaner/models/video_file.py
@@ -8,6 +8,7 @@ import cappa
 from box import Box
 from ffmpeg_progress_yield import FfmpegProgress
 from iso639 import Lang
+from iso639.exceptions import DeprecatedLanguageValue, InvalidLanguageValue
 from nclutils import pp
 from rich.markdown import Markdown
 from rich.progress import Progress
@@ -29,7 +30,16 @@ from vid_cleaner.constants import (
     CodecTypes,
     VideoTrait,
 )
-from vid_cleaner.utils import get_probe_as_box, query_radarr, query_sonarr, query_tmdb, run_ffprobe
+from vid_cleaner.utils import (
+    MediaId,
+    find_media_ids,
+    get_probe_as_box,
+    query_radarr,
+    query_sonarr,
+    query_tmdb,
+    query_tmdb_by_id,
+    run_ffprobe,
+)
 
 from vid_cleaner.controllers import TempFile  # isort: skip
 
@@ -291,32 +301,24 @@ class VideoFile:
         pp.trace(f"PROCESS AUDIO: Downmix command: {downmix_command}")
         return downmix_command, streams_to_drop
 
-    def _find_original_language(self) -> Lang:  # pragma: no cover
-        """Find the original language of the video content.
+    def _language_for(self, media_id: MediaId) -> Lang | None:
+        """Resolve a single media ID to the content's original language.
 
-        Query external APIs (IMDb, TMDB, Radarr, Sonarr) to determine the original language. Cache results to avoid repeated API calls.
+        Args:
+            media_id (MediaId): The identifier to look up.
 
         Returns:
-            Lang: The determined original language code
+            Lang | None: The original language, or None when it cannot be resolved.
         """
-        if self.ran_language_check:
-            return self.language
-
-        original_language = None
-
-        # Extract IMDb ID from filename if present (e.g. "Movie.Title.tt1234567.mkv")
-        match = re.search(r"(tt\d+)", self.stem)
-        imdb_id = match.group(0) if match else self._query_arr_apps_for_imdb_id()
-
-        response = query_tmdb(imdb_id) if imdb_id else None
-
-        if response and response.get("movie_results", None):
-            original_language = response["movie_results"][0].get("original_language")
-        if response and response.get("tv_results", None):
-            original_language = response["tv_results"][0].get("original_language")
+        if media_id.source == "imdb":
+            response = query_tmdb(media_id.value)
+            results = response.get("movie_results") or response.get("tv_results") or []
+            original_language = results[0].get("original_language") if results else None
+        else:
+            response = query_tmdb_by_id(tmdb_id=media_id.value, media_type=media_id.media_type)
+            original_language = response.get("original_language")
 
         if not original_language:
-            pp.debug(f"Could not find original language for: {self.name}")
             return None
 
         # TMDB uses 'cn' for Chinese but iso639 expects 'zh'
@@ -324,14 +326,50 @@ class VideoFile:
             original_language = "zh"
 
         try:
-            language = Lang(original_language)
-        except Exception:  # noqa: BLE001
-            pp.debug(f"iso639: Could not find language for: {self.name}")
+            return Lang(original_language)
+        except (InvalidLanguageValue, DeprecatedLanguageValue):
+            pp.debug(f"iso639: Unusable language '{original_language}' for: {self.name}")
             return None
 
-        self.language = language
+    def _find_original_language(self) -> Lang | None:
+        """Find the original language of the video content.
+
+        Check every ID discoverable from the filename and container tags, then fall back
+        to a Radarr/Sonarr title search. Cache the outcome so a miss is not retried.
+
+        Returns:
+            Lang | None: The determined language, or None when none could be found.
+        """
+        if self.ran_language_check:
+            return self.language
+
+        # Cache the attempt itself, so a miss does not re-query every API on each call
         self.ran_language_check = True
-        return language
+
+        media_ids = find_media_ids(stem=self.stem, format_tags=self.probe_box.format.tags)
+
+        for media_id in media_ids:
+            if language := self._language_for(media_id):
+                self.language = language
+                return language
+
+        # Last resort: Radarr/Sonarr require a network round trip, so only ask
+        # once every filename- and container-derived ID has failed to resolve.
+        imdb_id = self._query_arr_apps_for_imdb_id()
+
+        # Skip IDs already tried above; every one of them just failed to resolve
+        tried_imdb_ids = {media_id.value for media_id in media_ids if media_id.source == "imdb"}
+
+        if (
+            imdb_id
+            and imdb_id not in tried_imdb_ids
+            and (language := self._language_for(MediaId(source="imdb", value=imdb_id)))
+        ):
+            self.language = language
+            return language
+
+        pp.debug(f"Could not find original language for: {self.name}")
+        return None
 
     def _need_stream_reorder(self) -> bool:
         """Check if the video file needs stream reordering.
@@ -452,7 +490,7 @@ class VideoFile:
                     not settings.drop_local_subs
                     and langs
                     and original_language not in langs
-                    and (stream.language.lower == "und" or Lang(stream.language) in langs)
+                    and (stream.language.lower() == "und" or Lang(stream.language) in langs)
                 ):
                     pp.trace(f"PROCESS SUBTITLES: Keep stream #{stream.index} (original language)")
                     command.extend(["-map", f"0:{stream.index}"])
@@ -492,7 +530,7 @@ class VideoFile:
             str | None: The IMDb ID if found, otherwise None.
         """
         response = query_radarr(self.name)
-        if response and "movie" in response and "imdbId" in response["parsedMovieInfo"]:
+        if response and "movie" in response and "imdbId" in response["movie"]:
             return response["movie"]["imdbId"]
 
         response = query_sonarr(self.name)

--- a/src/vid_cleaner/utils/__init__.py
+++ b/src/vid_cleaner/utils/__init__.py
@@ -1,8 +1,9 @@
 """Shared utilities."""
 
-from .api_utils import query_radarr, query_sonarr, query_tmdb
+from .api_utils import query_radarr, query_sonarr, query_tmdb, query_tmdb_by_id
 from .console import render_substeps
 from .ffmpeg_utils import channels_to_layout, get_probe_as_box, run_ffprobe
+from .media_ids import MediaId, find_media_ids
 
 from .cli import (  # isort: skip
     coerce_video_files,
@@ -13,15 +14,18 @@ from .cli import (  # isort: skip
 )
 
 __all__ = [
+    "MediaId",
     "channels_to_layout",
     "coerce_video_files",
     "copy_to_output",
     "create_default_config",
+    "find_media_ids",
     "get_probe_as_box",
     "parse_trait_filters",
     "query_radarr",
     "query_sonarr",
     "query_tmdb",
+    "query_tmdb_by_id",
     "render_substeps",
     "resolve_out_path_override",
     "run_ffprobe",

--- a/src/vid_cleaner/utils/api_utils.py
+++ b/src/vid_cleaner/utils/api_utils.py
@@ -1,5 +1,7 @@
 """API utilities."""
 
+from typing import Literal
+
 import httpx
 from nclutils import pp
 from rich.json import JSON
@@ -42,6 +44,47 @@ def query_tmdb(search: str) -> dict:  # pragma: no cover
     pp.trace("TMDB: Response received", details=[JSON(response.text)])
 
     return response.json()
+
+
+def query_tmdb_by_id(tmdb_id: str, media_type: Literal["movie", "tv"] | None = None) -> dict:
+    """Query The Movie Database API by its own ID rather than an external ID.
+
+    Args:
+        tmdb_id (str): The TMDB numeric ID to look up.
+        media_type (Literal["movie", "tv"] | None): The record type. When None, try
+            movie first and fall back to tv.
+
+    Returns:
+        dict: The Movie Database API response, or an empty dict when not found.
+    """
+    tmdb_api_key = settings.TMDB_API_KEY
+
+    if not tmdb_api_key:
+        return {}
+
+    for candidate_type in [media_type] if media_type else ["movie", "tv"]:
+        url = f"https://api.themoviedb.org/3/{candidate_type}/{tmdb_id}"
+        params = {"api_key": tmdb_api_key, "language": "en-US"}
+
+        pp.trace(f"TMDB: Query {url}")
+
+        try:
+            response = httpx.get(url, params=params, timeout=15)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            # A 404 only means this was the wrong record type, so try the next one
+            if e.response.status_code == httpx.codes.NOT_FOUND:
+                continue
+            pp.error(str(e))
+            return {}
+        except httpx.HTTPError as e:
+            pp.error(str(e))
+            return {}
+
+        pp.trace("TMDB: Response received", details=[JSON(response.text)])
+        return response.json()
+
+    return {}
 
 
 def query_radarr(search: str) -> dict:  # pragma: no cover

--- a/src/vid_cleaner/utils/media_ids.py
+++ b/src/vid_cleaner/utils/media_ids.py
@@ -1,0 +1,84 @@
+"""Discover media IDs from filenames and container metadata."""
+
+import re
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from box import Box
+
+IMDB_ID_REGEX = re.compile(r"(tt\d+)")
+TMDB_STEM_REGEX = re.compile(r"tmdb(?:id)?-(\d+)", re.IGNORECASE)
+TMDB_TAG_REGEX = re.compile(r"(?:(movie|tv)/)?(\d+)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class MediaId:
+    """A media database identifier discovered for a video file."""
+
+    source: Literal["imdb", "tmdb"]
+    value: str
+    media_type: Literal["movie", "tv"] | None = None
+
+
+def find_media_ids(stem: str, format_tags: Box) -> list[MediaId]:
+    """Collect every media ID discoverable from a filename stem and container tags.
+
+    Prefer IDs embedded in the filename over the container's tags, since the filename
+    reflects how the user's media manager named the file while container tags come from
+    whoever built the release and may be stale.
+
+    Args:
+        stem: The video file's name without its suffix.
+        format_tags: The container's `format.tags` mapping from ffprobe.
+
+    Returns:
+        list[MediaId]: Ordered, deduplicated IDs. Empty when none are found.
+    """
+    candidates: list[MediaId] = []
+
+    if match := IMDB_ID_REGEX.search(stem):
+        candidates.append(MediaId(source="imdb", value=match.group(1)))
+
+    if match := TMDB_STEM_REGEX.search(stem):
+        candidates.append(MediaId(source="tmdb", value=match.group(1)))
+
+    tags = {str(key).lower(): str(value) for key, value in (format_tags or {}).items()}
+
+    if (imdb_tag := tags.get("imdb")) and (match := IMDB_ID_REGEX.search(imdb_tag)):
+        candidates.append(MediaId(source="imdb", value=match.group(1)))
+
+    if (tmdb_tag := tags.get("tmdb")) and (match := TMDB_TAG_REGEX.search(tmdb_tag)):
+        # The regex only ever captures "movie", "tv", or nothing, but mypy can't see that.
+        media_type = (
+            cast("Literal['movie', 'tv']", match.group(1).lower()) if match.group(1) else None
+        )
+        candidates.append(MediaId(source="tmdb", value=match.group(2), media_type=media_type))
+
+    return _dedupe(candidates)
+
+
+def _dedupe(candidates: list[MediaId]) -> list[MediaId]:
+    """Collapse duplicate (source, value) IDs, keeping first position but preferring a typed one.
+
+    TMDB's movie and TV ID sequences are separate and both start at 1, so an untyped
+    ID may collide with an unrelated typed one. Letting a later typed duplicate
+    upgrade an earlier untyped entry avoids querying the wrong TMDB namespace.
+
+    Args:
+        candidates: Media IDs in discovery order, possibly containing duplicates.
+
+    Returns:
+        list[MediaId]: Deduplicated IDs, preserving each kept entry's original position.
+    """
+    seen: dict[tuple[str, str], int] = {}
+    deduped: list[MediaId] = []
+    for candidate in candidates:
+        key = (candidate.source, candidate.value)
+        if key not in seen:
+            seen[key] = len(deduped)
+            deduped.append(candidate)
+        elif candidate.media_type and not deduped[seen[key]].media_type:
+            # movie and tv IDs collide, so a known type must win over an untyped duplicate
+            deduped[seen[key]] = candidate
+
+    return deduped

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+from box import Box
 from rich.console import Console
 
 from vid_cleaner.utils import get_probe_as_box
@@ -95,3 +96,27 @@ def mock_ffmpeg(mocker):
     mock_instance = mock_ffmpeg_progress.return_value
     mock_instance.run_command_with_progress.return_value = iter([0, 25, 50, 75, 100])
     return mock_ffmpeg_progress
+
+
+@pytest.fixture
+def mock_probe_tags(mocker):
+    """Patch VideoFile.probe_box to expose only the given container format tags.
+
+    Lets language-discovery tests control `format.tags` without a full ffprobe fixture.
+
+    Usage:
+        def test_something(mock_probe_tags):
+            mock_probe_tags({"TMDB": "movie/1399"})
+
+    Returns:
+        Callable[[dict[str, str] | None], None]: Call with a tags mapping (or nothing
+            for no tags) to patch `get_probe_as_box` accordingly.
+    """
+
+    def _inner(tags: dict[str, str] | None = None) -> None:
+        mocker.patch(
+            "vid_cleaner.models.video_file.get_probe_as_box",
+            return_value=Box({"format": {"tags": tags or {}}}, default_box=True),
+        )
+
+    return _inner

--- a/tests/fixtures/ffprobe/und_subtitle.json
+++ b/tests/fixtures/ffprobe/und_subtitle.json
@@ -1,0 +1,224 @@
+// Streams:
+// 0: 1080p H264 video
+// 1: 7.1 TrueHD, eng
+// 2: 5.1 AC3, eng
+// 3: 5.1 AC3, french
+// 4: stereo AC3, eng
+// 5: stereo AC3, eng (Commentary)
+// 6: English Subtitles
+// 7: Undetermined language Subtitles (regression fixture for the "und" keep/drop bug)
+// 8: French Subtitles
+// 9: cover.jpg
+{
+    // Variant of reference.json where the Danish subtitle track is retagged "und" to
+    // exercise the "keep subtitles in an undetermined language" branch of _process_subtitles.
+    "format": {
+        "bit_rate": "26192239",
+        "duration": "60.268000",
+        "filename": "test_movie.mkv",
+        "format_long_name": "Matroska / WebM",
+        "format_name": "matroska,webm",
+        "size": "197319234",
+        "start_time": "0.000000",
+        "tags": {
+            "ENCODER": "Lavf60.3.100",
+            "title": "Test Move"
+        }
+    },
+    "streams": [
+        // 0: 1080p H264 video
+        {
+            "index": 0,
+            "codec_long_name": "H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10",
+            "codec_name": "h264",
+            "codec_type": "video",
+            "coded_height": 1080,
+            "coded_width": 1920,
+            "height": 1080,
+            "sample_aspect_ratio": "1:1",
+            "start_time": "0.000000",
+            "tags": {
+                "BPS": "16232147",
+                "DURATION": "00:01:00.226000000",
+                "NUMBER_OF_BYTES": "15505439888",
+                "NUMBER_OF_FRAMES": "183221",
+                "language": "eng",
+                "title": "Test Movie"
+            },
+            "width": 1920
+        },
+        // Audio Streams
+        // ############################################################################
+        // 1: 7.1 TrueHD, eng
+        {
+            "index": 1,
+            "codec_name": "truehd",
+            "codec_long_name": "TrueHD",
+            "codec_type": "audio",
+            "sample_rate": "48000",
+            "channels": 8,
+            "channel_layout": "7.1",
+            "start_time": "0.000000",
+            "bits_per_raw_sample": "24",
+            "tags": {
+                "language": "eng",
+                "BPS": "3123209",
+                "NUMBER_OF_FRAMES": "11766956",
+                "NUMBER_OF_BYTES": "3828195236",
+                "SOURCE_ID": "001100",
+                "DURATION": "00:01:00.000000000"
+            }
+        },
+        // 2: 5.1 AC3, eng
+        {
+            "index": 2,
+            "codec_name": "ac3",
+            "codec_long_name": "ATSC A/52A (AC-3)",
+            "codec_type": "audio",
+            "sample_rate": "48000",
+            "channels": 6,
+            "channel_layout": "5.1(side)",
+            "bit_rate": "448000",
+            "tags": {
+                "language": "eng",
+                "BPS": "448000",
+                "NUMBER_OF_FRAMES": "306432",
+                "NUMBER_OF_BYTES": "549126144",
+                "SOURCE_ID": "001100",
+                "DURATION": "00:01:00.000000000"
+            }
+        },
+        // 3: 5.1 AC3, fre
+        {
+            "index": 3,
+            "codec_name": "ac3",
+            "codec_long_name": "ATSC A/52A (AC-3)",
+            "codec_type": "audio",
+            "sample_rate": "48000",
+            "channels": 6,
+            "channel_layout": "5.1(side)",
+            "bit_rate": "640000",
+            "tags": {
+                "language": "fre",
+                "BPS": "640000",
+                "NUMBER_OF_FRAMES": "306432",
+                "NUMBER_OF_BYTES": "784465920",
+                "SOURCE_ID": "001101",
+                "DURATION": "00:01:00.023000000"
+            }
+        },
+        // 4: stereo AC3, eng
+        {
+            "index": 4,
+            "codec_name": "ac3",
+            "codec_long_name": "ATSC A/52A (AC-3)",
+            "codec_type": "audio",
+            "sample_rate": "48000",
+            "channels": 2,
+            "channel_layout": "stereo",
+            "bit_rate": "224000",
+            "tags": {
+                "language": "eng",
+                "BPS": "224000",
+                "NUMBER_OF_FRAMES": "306432",
+                "NUMBER_OF_BYTES": "274563072",
+                "SOURCE_ID": "001106",
+                "DURATION": "00:01:00.000000000"
+            }
+        },
+        // :5 stereo AC3, eng (Commentary)
+        {
+            "index": 5,
+            "codec_name": "ac3",
+            "codec_long_name": "ATSC A/52A (AC-3)",
+            "codec_type": "audio",
+            "sample_rate": "48000",
+            "channels": 2,
+            "channel_layout": "stereo",
+            "bit_rate": "224000",
+            "tags": {
+                "language": "eng",
+                "BPS": "224000",
+                "NUMBER_OF_FRAMES": "306432",
+                "NUMBER_OF_BYTES": "274563072",
+                "SOURCE_ID": "001106",
+                "DURATION": "00:01:00.000000000",
+                "title": "Director's commentary"
+            }
+        },
+        // Subtitle Streams
+        // ############################################################################
+        // 6: English Subtitles
+        {
+            "index": 6,
+            "codec_name": "hdmv_pgs_subtitle",
+            "codec_long_name": "HDMV Presentation Graphic Stream subtitles",
+            "codec_type": "subtitle",
+            "start_time": "0.000000",
+            "duration_ts": 60268,
+            "duration": "60.268000",
+            "tags": {
+                "language": "eng",
+                "BPS": "33430",
+                "NUMBER_OF_FRAMES": "3576",
+                "NUMBER_OF_BYTES": "40688568",
+                "DURATION": "00:00:59.393000000"
+            }
+        },
+        // 7: Undetermined language Subtitles
+        {
+            "index": 7,
+            "codec_name": "hdmv_pgs_subtitle",
+            "codec_long_name": "HDMV Presentation Graphic Stream subtitles",
+            "codec_type": "subtitle",
+            "start_time": "0.000000",
+            "duration_ts": 60268,
+            "duration": "60.268000",
+            "tags": {
+                "language": "und",
+                "BPS": "28841",
+                "NUMBER_OF_FRAMES": "3616",
+                "NUMBER_OF_BYTES": "35234211",
+                "DURATION": "00:00:59.393000000"
+            }
+        },
+        // 8: French Subtitles
+        {
+            "index": 8,
+            "codec_name": "hdmv_pgs_subtitle",
+            "codec_long_name": "HDMV Presentation Graphic Stream subtitles",
+            "codec_type": "subtitle",
+            "start_time": "0.000000",
+            "duration_ts": 60268,
+            "duration": "60.268000",
+            "tags": {
+                "language": "fre",
+                "BPS": "28841",
+                "NUMBER_OF_FRAMES": "3616",
+                "NUMBER_OF_BYTES": "35234211",
+                "DURATION": "00:00:59.393000000"
+            }
+        },
+        // Attachment Streams
+        // ############################################################################
+        // 9: cover.jpg
+        {
+            "index": 9,
+            "codec_name": "mjpeg",
+            "codec_long_name": "Motion JPEG",
+            "profile": "Baseline",
+            "codec_type": "video",
+            "width": 640,
+            "height": 360,
+            "coded_width": 640,
+            "coded_height": 360,
+            "start_time": "0.000000",
+            "bits_per_raw_sample": "8",
+            "tags": {
+                "FILENAME": "cover.jpg",
+                "MIMETYPE": "image/jpeg",
+                "DURATION": "00:00:00.000000000"
+            }
+        }
+    ]
+}

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1,0 +1,125 @@
+# type: ignore
+"""Test API utilities."""
+
+import httpx
+import pytest
+
+from vid_cleaner import settings
+from vid_cleaner.utils import query_tmdb_by_id
+
+
+@pytest.fixture
+def tmdb_key():
+    """Provide a TMDB API key so the query is not short-circuited."""
+    # Dynaconf settings aren't real attributes, so mocker.patch.object's teardown
+    # deletes rather than restores them; save and restore the value by hand.
+    previous = settings.get("TMDB_API_KEY", "")
+    settings.set("TMDB_API_KEY", "test-key")
+    yield
+    settings.set("TMDB_API_KEY", previous)
+
+
+@pytest.fixture
+def tmdb_no_key():
+    """Clear the TMDB API key so the query is short-circuited."""
+    previous = settings.get("TMDB_API_KEY", "")
+    settings.set("TMDB_API_KEY", "")
+    yield
+    settings.set("TMDB_API_KEY", previous)
+
+
+def _response(status_code: int, payload: dict) -> httpx.Response:
+    """Build an httpx response bound to a request, as raise_for_status requires."""
+    return httpx.Response(
+        status_code=status_code,
+        json=payload,
+        request=httpx.Request("GET", "https://api.themoviedb.org/"),
+    )
+
+
+def test_returns_empty_without_api_key(tmdb_no_key, mocker):
+    """Verify no request is made when no API key is configured."""
+    # Given: No TMDB API key
+    get = mocker.patch("vid_cleaner.utils.api_utils.httpx.get")
+
+    # When: A lookup is attempted
+    result = query_tmdb_by_id(tmdb_id="55")
+
+    # Then: Nothing is requested and an empty dict comes back
+    assert result == {}
+    get.assert_not_called()
+
+
+def test_queries_movie_endpoint_when_type_known(tmdb_key, mocker):
+    """Verify a known media type queries only that endpoint."""
+    # Given: A movie record is available
+    get = mocker.patch(
+        "vid_cleaner.utils.api_utils.httpx.get",
+        return_value=_response(status_code=200, payload={"original_language": "es"}),
+    )
+
+    # When: A typed lookup runs
+    result = query_tmdb_by_id(tmdb_id="55", media_type="movie")
+
+    # Then: The movie endpoint is queried exactly once
+    assert result == {"original_language": "es"}
+    assert get.call_count == 1
+    assert get.call_args[0][0] == "https://api.themoviedb.org/3/movie/55"
+
+
+def test_falls_back_to_tv_when_movie_missing(tmdb_key, mocker):
+    """Verify an untyped lookup retries against tv after the movie endpoint 404s."""
+    # Given: The ID is a tv record, so the movie endpoint 404s
+    get = mocker.patch(
+        "vid_cleaner.utils.api_utils.httpx.get",
+        side_effect=[
+            _response(status_code=404, payload={"status_message": "not found"}),
+            _response(status_code=200, payload={"original_language": "ja"}),
+        ],
+    )
+
+    # When: An untyped lookup runs
+    result = query_tmdb_by_id(tmdb_id="1399")
+
+    # Then: Both endpoints are tried in order and the tv record is returned
+    assert result == {"original_language": "ja"}
+    assert get.call_count == 2
+    assert get.call_args_list[0][0][0] == "https://api.themoviedb.org/3/movie/1399"
+    assert get.call_args_list[1][0][0] == "https://api.themoviedb.org/3/tv/1399"
+
+
+def test_returns_empty_when_both_endpoints_miss(tmdb_key, mocker):
+    """Verify an ID found in neither endpoint yields an empty dict."""
+    # Given: Both endpoints 404
+    get = mocker.patch(
+        "vid_cleaner.utils.api_utils.httpx.get",
+        side_effect=[
+            _response(status_code=404, payload={"status_message": "not found"}),
+            _response(status_code=404, payload={"status_message": "not found"}),
+        ],
+    )
+
+    # When: An untyped lookup runs
+    result = query_tmdb_by_id(tmdb_id="999999999")
+
+    # Then: Both endpoints are tried and nothing is returned
+    assert result == {}
+    assert get.call_count == 2
+    assert get.call_args_list[0][0][0] == "https://api.themoviedb.org/3/movie/999999999"
+    assert get.call_args_list[1][0][0] == "https://api.themoviedb.org/3/tv/999999999"
+
+
+def test_stops_on_non_404_error(tmdb_key, mocker):
+    """Verify a server error aborts rather than falling through to the tv endpoint."""
+    # Given: The movie endpoint returns a server error
+    get = mocker.patch(
+        "vid_cleaner.utils.api_utils.httpx.get",
+        return_value=_response(status_code=500, payload={"status_message": "server error"}),
+    )
+
+    # When: An untyped lookup runs
+    result = query_tmdb_by_id(tmdb_id="55")
+
+    # Then: It gives up without trying tv, since the error is not a type mismatch
+    assert result == {}
+    assert get.call_count == 1

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -83,24 +83,24 @@ def test_clean_out_with_multiple_files_errors(debug, tmp_path, capsys) -> None:
         pytest.param(
             ["--downmix"],
             "-map 0:0 -map 0:1 -map 0:2 -map 0:4",
-            "✔ Process file (downmix to stereo, drop unwanted subtitles)",
+            "✔ Process file (downmix to stereo)",
             id="Don't convert audio to stereo when stereo exists",
         ),
         pytest.param(
             ["--keep-commentary"],
             "-map 0:0 -map 0:1 -map 0:2 -map 0:4 -map 0:5",
-            "✔ Process file (keep commentary, drop unwanted subtitles)",
+            "✔ Process file (keep commentary)",
             id="Keep commentary",
         ),
         pytest.param(
             ["--drop-original"],
             "-map 0:0 -map 0:1 -map 0:2 -map 0:4",
-            "✔ Process file (drop original audio, drop unwanted subtitles)",
+            "✔ Process file (drop original audio)",
             id="Keep local language from config even when dropped",
         ),
         pytest.param(
             ["--langs", "fr,es"],
-            "-map 0:0 -map 0:3 -map 0:8",
+            "-map 0:0 -map 0:1 -map 0:2 -map 0:3 -map 0:4 -map 0:8",
             "✔ Process file (drop unwanted subtitles)",
             id="Keep specified languages",
         ),
@@ -142,7 +142,7 @@ def test_stream_processing(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Running clean command
     with pytest.raises(cappa.Exit) as exc_info:
@@ -164,12 +164,60 @@ def test_stream_processing(
     assert "cleaned_video.mkv" in output
 
 
+def test_clean_video_foreign_language_keeps_und_subtitle(
+    mocker,
+    mock_video_path,
+    capsys,
+    tmp_path,
+    mock_ffprobe_box,
+    mock_ffmpeg,
+    debug,
+):
+    """Verify a subtitle tagged "und" is kept when the original audio language differs.
+
+    Regression test for a bug where `stream.language.lower` was compared to `"und"`
+    without calling it, so the comparison was always False and the "und" subtitle was
+    silently dropped instead of kept.
+    """
+    # Given: a video whose original audio language (fr) is not in langs_to_keep (en),
+    # forcing the "keep subtitles when original audio differs" branch to decide, and a
+    # subtitle stream tagged "und" that branch must keep
+    args = ["clean", "-vv", str(mock_video_path)]
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("und_subtitle.json"),
+    )
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("fr"))
+
+    # When: processing the video file
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: the "und" subtitle (index 7) is kept alongside the English subtitle (index 6),
+    # while the French subtitle (index 8) is dropped
+    mock_ffmpeg.assert_called_once()
+    call_args, _ = mock_ffmpeg.call_args
+    command = " ".join(call_args[0])
+    assert exc_info.value.code == 0
+    assert "-map 0:6" in command
+    assert "-map 0:7" in command
+    assert "-map 0:8" not in command
+    assert "✔ No streams to reorder" in output
+    assert "cleaned_video.mkv" in output
+
+
 @pytest.mark.parametrize(
     ("args", "command_expected", "process_output"),
     [
         pytest.param(
             [],
-            "-map 0:0 -map 0:1 -map 0:2 -map 0:4 -map 0:6",
+            "-map 0:0 -map 0:1 -map 0:2 -map 0:3 -map 0:4 -map 0:6",
             "✔ Process file (drop unwanted subtitles)",
             id="Defaults keep local and original audio, local subs",
         ),
@@ -181,7 +229,7 @@ def test_stream_processing(
         ),
         pytest.param(
             ["--drop-local-subs"],
-            "-map 0:0 -map 0:1 -map 0:2 -map 0:4",
+            "-map 0:0 -map 0:1 -map 0:2 -map 0:3 -map 0:4",
             "✔ Process file",
             id="Drop local subs",
         ),
@@ -211,7 +259,7 @@ def test_clean_video_foreign_language(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("fr")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("fr"))
 
     # When: Processing the video file
     with pytest.raises(cappa.Exit) as exc_info:
@@ -274,7 +322,7 @@ def test_clean_video_downmix(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Processing the video file
     with pytest.raises(cappa.Exit) as exc_info:
@@ -315,7 +363,7 @@ def test_clean_video_downmix_stereo_commentary_kept(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Processing the video file with downmix requested
     with pytest.raises(cappa.Exit) as exc_info:
@@ -355,7 +403,7 @@ def test_clean_video_downmix_unmapped_channel_count(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Processing the video file with downmix requested
     with pytest.raises(cappa.Exit) as exc_info:
@@ -386,7 +434,7 @@ def test_clean_video_downmix_dialogue_forward_filter(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Processing the video file with downmix requested
     with pytest.raises(cappa.Exit):
@@ -421,7 +469,7 @@ def test_clean_video_downmix_atmos(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Processing the video file with downmix requested
     with pytest.raises(cappa.Exit) as exc_info:
@@ -458,7 +506,7 @@ def test_clean_video_downmix_does_not_clobber_kept_stream(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Processing the video file with downmix requested
     with pytest.raises(cappa.Exit):
@@ -482,7 +530,7 @@ def test_clean_video_downmix_does_not_clobber_kept_stream(
             [],
             "-c copy -map 0:2 -map 0:1 -map 0:3 -map 0:0",
             "-map 0:2 -map 0:1 -map 0:3",
-            "✔ No streams to process",
+            "✔ Process file",
             id="Defaults, reorder streams, then process streams",
         ),
     ],
@@ -512,7 +560,7 @@ def test_clean_reorganize_streams(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Processing the video file
     with pytest.raises(cappa.Exit) as exc_info:
@@ -520,12 +568,17 @@ def test_clean_reorganize_streams(
 
     output = capsys.readouterr().out
 
-    # THEN verify ffmpeg is called once - once to reorder streams, stream processing is skipped
-    assert mock_ffmpeg.call_count == 1
+    # THEN verify ffmpeg is called twice - once to reorder streams, once to drop the
+    # local-language subtitle (kept only when it differs from the original audio language)
+    assert mock_ffmpeg.call_count == 2
 
     # AND verify the first ffmpeg command contains expected stream reordering
     first_command = " ".join(mock_ffmpeg.mock_calls[0].args[0])
     assert first_command_expected in first_command
+
+    # AND verify the second ffmpeg command contains expected stream processing
+    second_command = " ".join(mock_ffmpeg.mock_calls[2].args[0])
+    assert second_command_expected in second_command
 
     # AND verify the command output indicates successful processing
     assert exc_info.value.code == 0
@@ -577,7 +630,7 @@ def test_convert_video(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
     mocker.patch.object(TempFile, "new_tmp_path", return_value=(mock_video_path))
     mocker.patch.object(TempFile, "latest_temp_path", return_value=(mock_video_path))
 
@@ -638,7 +691,7 @@ def test_save_each_step(
             (Path("cleaned_video.mkv"), ["✔ Saved to cleaned_video.mkv"]),
         ],
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
     mocker.patch.object(TempFile, "new_tmp_path", return_value=(mock_video_path))
     mocker.patch.object(TempFile, "latest_temp_path", return_value=(mock_video_path))
 
@@ -668,7 +721,7 @@ def test_save_each_step(
     assert "✔ No streams to reorder" in output
     assert "✔ Process file" in output
     assert "cleaned_video.mkv" in output
-    assert "✔ Process file (downmix to stereo, drop unwanted subtitles)" in output
+    assert "✔ Process file (downmix to stereo)" in output
     assert "✔ Convert to H.265" in output
     assert "cleaned_video.mkv" in output
 
@@ -698,7 +751,7 @@ def test_clean_multiple_files_use_distinct_output_paths(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, [f"✔ Saved to {dst}"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: cleaning both files in a single invocation
     with pytest.raises(cappa.Exit) as exc_info:
@@ -735,7 +788,7 @@ def test_clean_multiple_files_overwrite_each_in_place(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, [f"✔ Saved to {dst}"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: cleaning both files in place
     with pytest.raises(cappa.Exit) as exc_info:
@@ -763,7 +816,7 @@ def test_clean_renders_completed_steps_on_error(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
     mocker.patch.object(
         VideoFile, "convert_to_h265", autospec=True, side_effect=RuntimeError("boom")
     )
@@ -796,7 +849,7 @@ def test_clean_video_downmix_skip_when_stereo_exists(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Processing with downmix requested but not forced
     with pytest.raises(cappa.Exit) as exc_info:
@@ -833,7 +886,7 @@ def test_clean_video_downmix_force_recreates_stereo(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Processing with downmix forced
     with pytest.raises(cappa.Exit) as exc_info:
@@ -847,11 +900,13 @@ def test_clean_video_downmix_force_recreates_stereo(
     # Then: The old stereo (index 4) is dropped and a fresh downmix is built from the 5.1
     # (index 2). Two audio streams remain mapped, so the downmix is output audio index 2.
     assert exc_info.value.code == 0
-    assert "-map 0:0 -map 0:1 -map 0:2 -map 0:6" in command
+    assert "-map 0:0 -map 0:1 -map 0:2" in command
     assert "-map 0:2 -c:a:2 aac -ac:a:2 2 -b:a:2 256k -filter:a:2" in command
     assert "-map 0:4" not in command
-    # reference.json keeps an English subtitle, so the title also carries the subtitle flag
-    assert "✔ Process file (downmix to stereo, drop unwanted subtitles)" in output
+    # reference.json's English subtitle matches langs_to_keep and the original language,
+    # so it is dropped rather than kept, and the title carries no subtitle flag
+    assert "-map 0:6" not in command
+    assert "✔ Process file (downmix to stereo)" in output
 
 
 def test_clean_video_downmix_force_recreates_from_multiple_stereo(
@@ -873,7 +928,7 @@ def test_clean_video_downmix_force_recreates_from_multiple_stereo(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Forcing downmix with two stereo tracks present
     with pytest.raises(cappa.Exit) as exc_info:
@@ -912,7 +967,7 @@ def test_clean_video_downmix_force_no_surround_keeps_stereo(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Forcing downmix with no surround source to rebuild from
     with pytest.raises(cappa.Exit) as exc_info:
@@ -945,7 +1000,7 @@ def test_clean_video_downmix_force_noop_without_existing_stereo(
         "vid_cleaner.cli.clean_video.copy_to_output",
         side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
     )
-    mocker.patch.object(VideoFile, "_find_original_language", return_value=[Lang("en")])
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
 
     # When: Forcing downmix with no existing stereo mix
     with pytest.raises(cappa.Exit) as exc_info:
@@ -960,3 +1015,148 @@ def test_clean_video_downmix_force_noop_without_existing_stereo(
     assert exc_info.value.code == 0
     assert "-map 0:2 -c:a:2 aac -ac:a:2 2 -b:a:2 256k -filter:a:2" in command
     assert "✔ Process file (downmix to stereo)" in output
+
+
+# ---------------------------------------------------------------------------
+# VideoFile._find_original_language orchestration
+#
+# These call _find_original_language() directly rather than through the CLI,
+# mocking at the query_tmdb/query_tmdb_by_id/_query_arr_apps_for_imdb_id
+# boundary so the real ID-discovery and fallback ordering is exercised.
+# ---------------------------------------------------------------------------
+
+
+def test_find_original_language_skips_arr_when_filename_id_resolves(
+    mocker, tmp_path, mock_probe_tags
+) -> None:
+    """Verify Radarr/Sonarr are not queried once a filename-derived ID resolves."""
+    # Given: a filename carrying a resolvable IMDb ID and no container tags
+    path = tmp_path / "Some Movie (1999) tt0133093.mkv"
+    path.touch()
+    video_file = VideoFile(path)
+    mock_probe_tags()
+    mock_query_tmdb = mocker.patch(
+        "vid_cleaner.models.video_file.query_tmdb",
+        return_value={"movie_results": [{"original_language": "en"}]},
+    )
+    mock_query_arr = mocker.patch.object(VideoFile, "_query_arr_apps_for_imdb_id")
+
+    # When: finding the original language
+    result = video_file._find_original_language()  # noqa: SLF001
+
+    # Then: the filename's IMDb ID resolves the language and Radarr/Sonarr are never queried
+    assert result == Lang("en")
+    mock_query_tmdb.assert_called_once_with("tt0133093")
+    mock_query_arr.assert_not_called()
+
+
+def test_find_original_language_consults_arr_when_no_id_resolves(
+    mocker, tmp_path, mock_probe_tags
+) -> None:
+    """Verify Radarr/Sonarr are consulted as a last resort when no ID is discoverable."""
+    # Given: a filename and container with no discoverable media ID
+    path = tmp_path / "Some Movie (1999).mkv"
+    path.touch()
+    video_file = VideoFile(path)
+    mock_probe_tags()
+    mock_query_tmdb = mocker.patch(
+        "vid_cleaner.models.video_file.query_tmdb",
+        return_value={"movie_results": [{"original_language": "fr"}]},
+    )
+    mock_query_arr = mocker.patch.object(
+        VideoFile, "_query_arr_apps_for_imdb_id", return_value="tt0245712"
+    )
+
+    # When: finding the original language
+    result = video_file._find_original_language()  # noqa: SLF001
+
+    # Then: Radarr/Sonarr is queried and its IMDb ID resolves the language
+    assert result == Lang("fr")
+    mock_query_arr.assert_called_once()
+    mock_query_tmdb.assert_called_once_with("tt0245712")
+
+
+def test_find_original_language_caches_result(mocker, tmp_path, mock_probe_tags) -> None:
+    """Verify a second call reuses the cached language instead of re-querying."""
+    # Given: a filename with a resolvable IMDb ID
+    path = tmp_path / "Some Movie (1999) tt0133093.mkv"
+    path.touch()
+    video_file = VideoFile(path)
+    mock_probe_tags()
+    mock_query_tmdb = mocker.patch(
+        "vid_cleaner.models.video_file.query_tmdb",
+        return_value={"movie_results": [{"original_language": "en"}]},
+    )
+
+    # When: finding the original language twice
+    first = video_file._find_original_language()  # noqa: SLF001
+    second = video_file._find_original_language()  # noqa: SLF001
+
+    # Then: both calls return the cached language but only one query was made
+    assert first == Lang("en")
+    assert second == Lang("en")
+    mock_query_tmdb.assert_called_once()
+
+
+def test_find_original_language_falls_through_failed_candidate(
+    mocker, tmp_path, mock_probe_tags
+) -> None:
+    """Verify a failed first candidate falls through to the next discovered ID."""
+    # Given: a filename IMDb ID that fails to resolve and a container TMDB tag that does
+    path = tmp_path / "Some Movie (1999) tt9999999.mkv"
+    path.touch()
+    video_file = VideoFile(path)
+    mock_probe_tags({"TMDB": "movie/1399"})
+    mock_query_tmdb = mocker.patch("vid_cleaner.models.video_file.query_tmdb", return_value={})
+    mock_query_tmdb_by_id = mocker.patch(
+        "vid_cleaner.models.video_file.query_tmdb_by_id",
+        return_value={"original_language": "en"},
+    )
+
+    # When: finding the original language
+    result = video_file._find_original_language()  # noqa: SLF001
+
+    # Then: the unresolvable IMDb candidate is skipped and the TMDB candidate resolves
+    assert result == Lang("en")
+    mock_query_tmdb.assert_called_once_with("tt9999999")
+    mock_query_tmdb_by_id.assert_called_once_with(tmdb_id="1399", media_type="movie")
+
+
+@pytest.mark.parametrize(
+    ("radarr_response", "expected"),
+    [
+        pytest.param(
+            {"parsedMovieInfo": {"movieTitle": "Some Movie"}, "movie": {"imdbId": "tt0133093"}},
+            "tt0133093",
+            id="Radarr matched the movie",
+        ),
+        pytest.param(
+            {"parsedMovieInfo": {"movieTitle": "Some Movie"}},
+            None,
+            id="Radarr parsed the title but matched no movie",
+        ),
+        pytest.param(
+            {"movie": {"title": "Some Movie"}},
+            None,
+            id="Radarr matched a movie carrying no imdb id",
+        ),
+    ],
+)
+def test_query_arr_apps_for_imdb_id_radarr(mocker, tmp_path, radarr_response, expected) -> None:
+    """Verify the Radarr response is read for an IMDb ID without raising."""
+    # Given: a video file and a Radarr response
+    path = tmp_path / "Some Movie (1999).mkv"
+    path.touch()
+    video_file = VideoFile(path)
+    mocker.patch(
+        "vid_cleaner.models.video_file.query_radarr",
+        autospec=True,
+        return_value=radarr_response,
+    )
+    mocker.patch("vid_cleaner.models.video_file.query_sonarr", autospec=True, return_value={})
+
+    # When: querying the arr apps for an IMDb ID
+    result = video_file._query_arr_apps_for_imdb_id()  # noqa: SLF001
+
+    # Then: the IMDb ID is returned when present, otherwise None
+    assert result == expected

--- a/tests/test_media_ids.py
+++ b/tests/test_media_ids.py
@@ -1,0 +1,152 @@
+# type: ignore
+"""Test media ID discovery from filenames and container tags."""
+
+from box import Box
+
+from vid_cleaner.utils import MediaId, find_media_ids
+from vid_cleaner.utils.media_ids import _dedupe
+
+
+def test_finds_imdb_id_in_stem():
+    """Verify a bare IMDb ID in the filename stem is found."""
+    # Given: A stem carrying a bare IMDb ID
+    stem = "Some Movie (1999) tt0133093 [Bluray-1080p]"
+
+    # When: Media IDs are collected
+    result = find_media_ids(stem=stem, format_tags=Box({}))
+
+    # Then: The IMDb ID is returned
+    assert result == [MediaId(source="imdb", value="tt0133093")]
+
+
+def test_finds_tmdb_id_in_stem():
+    """Verify the Radarr/Sonarr {tmdb-NN} convention is found in the stem."""
+    # Given: A stem carrying a braced TMDB ID
+    stem = "Amores Perros (2000) {tmdb-55} [Bluray-1080p]"
+
+    # When: Media IDs are collected
+    result = find_media_ids(stem=stem, format_tags=Box({}))
+
+    # Then: The TMDB ID is returned with no media type
+    assert result == [MediaId(source="tmdb", value="55", media_type=None)]
+
+
+def test_finds_braced_imdb_id_in_stem():
+    """Verify the {imdb-ttNN} naming convention is found in the stem."""
+    # Given: A stem carrying a braced IMDb ID
+    stem = "Some Movie (1999) {imdb-tt0133093}"
+
+    # When: Media IDs are collected
+    result = find_media_ids(stem=stem, format_tags=Box({}))
+
+    # Then: The IMDb ID is returned without the brace prefix
+    assert result == [MediaId(source="imdb", value="tt0133093")]
+
+
+def test_finds_imdb_id_in_container_tags():
+    """Verify an IMDB container tag is read when the stem has no ID."""
+    # Given: A stem with no ID and a container IMDB tag
+    stem = "Some Movie (1999)"
+    tags = Box({"IMDB": "tt0245712"})
+
+    # When: Media IDs are collected
+    result = find_media_ids(stem=stem, format_tags=tags)
+
+    # Then: The tag's IMDb ID is returned
+    assert result == [MediaId(source="imdb", value="tt0245712")]
+
+
+def test_finds_typed_tmdb_container_tag():
+    """Verify a TMDB tag's movie/tv prefix is captured as the media type."""
+    # Given: A container TMDB tag carrying its media type
+    tags = Box({"TMDB": "movie/55"})
+
+    # When: Media IDs are collected
+    result = find_media_ids(stem="Some Movie (1999)", format_tags=tags)
+
+    # Then: The media type is captured
+    assert result == [MediaId(source="tmdb", value="55", media_type="movie")]
+
+
+def test_finds_untyped_tmdb_container_tag():
+    """Verify a bare numeric TMDB tag yields no media type."""
+    # Given: A container TMDB tag with no media type prefix
+    tags = Box({"TMDB": "55"})
+
+    # When: Media IDs are collected
+    result = find_media_ids(stem="Some Movie (1999)", format_tags=tags)
+
+    # Then: The media type is None
+    assert result == [MediaId(source="tmdb", value="55", media_type=None)]
+
+
+def test_ignores_tvdb_tag():
+    """Verify TVDB2 tags are not parsed, since TVDB is out of scope."""
+    # Given: A container carrying only a TVDB2 tag
+    tags = Box({"TVDB2": "movies/1982"})
+
+    # When: Media IDs are collected
+    result = find_media_ids(stem="Some Movie (1999)", format_tags=tags)
+
+    # Then: Nothing is returned
+    assert result == []
+
+
+def test_orders_stem_before_tags_and_dedupes():
+    """Verify stem IDs outrank container tags and duplicate IDs collapse."""
+    # Given: A file carrying IDs in both the stem and the container
+    stem = "Amores Perros (2000) {tmdb-55} [Bluray-1080p][AC3 5.1][x264]-ZoroSenpai"
+    tags = Box({"IMDB": "tt0245712", "TMDB": "movie/55", "TVDB2": "movies/1982"})
+
+    # When: Media IDs are collected
+    result = find_media_ids(stem=stem, format_tags=tags)
+
+    # Then: The stem's TMDB ID leads but is upgraded with the container's known
+    # media type, the container's IMDb ID follows, and the duplicate is dropped
+    assert result == [
+        MediaId(source="tmdb", value="55", media_type="movie"),
+        MediaId(source="imdb", value="tt0245712", media_type=None),
+    ]
+
+
+def test_untyped_stem_id_upgraded_by_typed_tag_keeps_position():
+    """Verify a typed container duplicate upgrades an untyped stem ID in place."""
+    # Given: An untyped TMDB ID in the stem and a typed duplicate in the container tags
+    stem = "Amores Perros (2000) {tmdb-55}"
+    tags = Box({"TMDB": "movie/55"})
+
+    # When: Media IDs are collected
+    result = find_media_ids(stem=stem, format_tags=tags)
+
+    # Then: The single entry keeps its leading position but gains the media type
+    assert result == [MediaId(source="tmdb", value="55", media_type="movie")]
+
+
+def test_dedupe_does_not_downgrade_typed_entry():
+    """Verify a typed entry is not overwritten by a later untyped duplicate.
+
+    find_media_ids always discovers the untyped stem candidate before the (possibly
+    typed) tag candidate, so this ordering cannot be produced through the public
+    API. Exercise the dedup step directly instead.
+    """
+    # Given: A typed TMDB entry followed by an untyped duplicate
+    candidates = [
+        MediaId(source="tmdb", value="55", media_type="movie"),
+        MediaId(source="tmdb", value="55", media_type=None),
+    ]
+
+    # When: Candidates are deduped
+    result = _dedupe(candidates)
+
+    # Then: The typed entry is kept, not overwritten by the untyped duplicate
+    assert result == [MediaId(source="tmdb", value="55", media_type="movie")]
+
+
+def test_returns_empty_when_nothing_found():
+    """Verify a file with no discoverable ID yields an empty list."""
+    # Given: A stem and tags with no IDs
+    # When: Media IDs are collected
+    result = find_media_ids(stem="Some Movie (1999)", format_tags=Box({}))
+
+    # Then: Nothing is returned
+    assert result == []


### PR DESCRIPTION
## Summary

`VideoFile._find_original_language` now collects every IMDb and TMDB id available from the filename stem and the container's `format.tags`, resolves each through TMDB in order, and falls back to a Radarr or Sonarr title search only when none of them resolve. Previously it matched a bare `tt` id in the filename and otherwise went straight to the title search.

## Changes

- Add `vid_cleaner/utils/media_ids.py` with a frozen `MediaId` dataclass and `find_media_ids()`, parsing `tt\d+` and `{tmdb-NN}` ids from a filename stem and `IMDB`/`TMDB` ids from container format tags. Results are ordered filename-first and deduplicated by `(source, value)`, where a duplicate carrying a `movie` or `tv` media type replaces an untyped entry in place.
- Add `query_tmdb_by_id()` to `utils/api_utils.py`, querying `/3/movie/{id}` and `/3/tv/{id}`. With no media type it tries `movie` first and falls back to `tv` on a 404, returning `{}` on any other error.
- Split single-id resolution into `VideoFile._language_for()`, which reads `movie_results`/`tv_results` for IMDb ids and top-level `original_language` for TMDB ids, applies the `cn` to `zh` mapping, and narrows the `Lang` construction guard from bare `Exception` to `InvalidLanguageValue` and `DeprecatedLanguageValue`.
- Set `ran_language_check` immediately after the cache guard, so a failed lookup is not retried on later calls.
- Change `_find_original_language`'s return annotation from `Lang` to `Lang | None`.
- Read the Radarr IMDb id from `response["movie"]` instead of gating on `"imdbId" in response["parsedMovieInfo"]`.
- Add the missing call parentheses to `stream.language.lower` in `_process_subtitles`.
- Document the id lookup order and the required config keys in the README.
- Add `tests/test_media_ids.py`, `tests/test_api_utils.py`, a `mock_probe_tags` conftest fixture, orchestration tests for `_find_original_language`, a Radarr response test, and an `und_subtitle.json` ffprobe fixture.
- Correct existing mocks of `_find_original_language` that returned `[Lang("fr")]` rather than `Lang("fr")`, and update the stream maps those tests assert.
