### PR TITLE
feat(clean): report the operations actually performed

### DIFF
--- a/src/vid_cleaner/cli/clean_video.py
+++ b/src/vid_cleaner/cli/clean_video.py
@@ -64,14 +64,14 @@ def main(clean_cmd: CleanCommand) -> None:
     for video_file in coerce_video_files(clean_cmd.files):
         settings.out_path = out_path_override or video_file.path
 
-        # Print the video name first so live progress bars render beneath it, then collect the
-        # run's outcome and render the result tree once the file is done. The render runs in
-        # `finally` so completed steps are still shown if the operation raises.
+        # Print the video name first so live progress bars and clean()'s up-front operation
+        # tree render beneath it. Only the write-output messages are collected here and
+        # rendered in `finally`, so they still show if `write_output()` raises.
         pp.info(f"⇨ {video_file.path.name}")
         substeps: list[str] = []
 
         try:
-            substeps.extend(video_file.clean())
+            video_file.clean()
             if not settings.dryrun:
                 substeps.extend(write_output(video_file))
         finally:

--- a/src/vid_cleaner/config.py
+++ b/src/vid_cleaner/config.py
@@ -86,6 +86,7 @@ class SettingsManager:
                 cast=bool,
             ),
             Validator("out_path", default=None),
+            Validator("verbosity", default=0, cast=int),
             Validator(
                 "radarr_url",
                 default="",

--- a/src/vid_cleaner/constants.py
+++ b/src/vid_cleaner/constants.py
@@ -93,6 +93,7 @@ class Resolution:
 
 
 SYMBOL_CHECK = "✔"
+SYMBOL_CROSS = "✖"  # Marks a requested operation that was skipped, in debug output
 TREE_BRANCH = "├─"  # Connector for a non-final child line in faked step output
 TREE_LAST = "└─"  # Connector for the final child line in faked step output
 COMMENTARY_STREAM_TITLE_REGEX = r"commentary|sdh|description"

--- a/src/vid_cleaner/constants.py
+++ b/src/vid_cleaner/constants.py
@@ -94,6 +94,8 @@ class Resolution:
 
 SYMBOL_CHECK = "✔"
 SYMBOL_CROSS = "✖"  # Marks a requested operation that was skipped, in debug output
+# Shared so the VP9 planner can correct the subtitle action recorded under this exact label
+DROP_SUBTITLES_LABEL = "Drop unwanted subtitles"
 TREE_BRANCH = "├─"  # Connector for a non-final child line in faked step output
 TREE_LAST = "└─"  # Connector for the final child line in faked step output
 COMMENTARY_STREAM_TITLE_REGEX = r"commentary|sdh|description"

--- a/src/vid_cleaner/models/__init__.py
+++ b/src/vid_cleaner/models/__init__.py
@@ -1,6 +1,6 @@
 """Models for vid-cleaner app."""
 
-from .conversion_plan import ConversionPlan, OutputStream
+from .conversion_plan import ConversionPlan, OutputStream, PlanAction
 from .video_file import VideoFile
 
-__all__ = ["ConversionPlan", "OutputStream", "VideoFile"]
+__all__ = ["ConversionPlan", "OutputStream", "PlanAction", "VideoFile"]

--- a/src/vid_cleaner/models/conversion_plan.py
+++ b/src/vid_cleaner/models/conversion_plan.py
@@ -65,14 +65,12 @@ class ConversionPlan:
             subtitles). Mapping order performs any stream reordering for free.
         global_args (list[str]): Output-wide args appended after per-stream options.
         output_suffix (str | None): Container suffix override (e.g. ".webm").
-        substeps (list[str]): Result-tree messages describing the applied operations.
         actions (list[PlanAction]): Cleaning operations the plan considered.
     """
 
     streams: list[OutputStream] = field(default_factory=list)
     global_args: list[str] = field(default_factory=list)
     output_suffix: str | None = None
-    substeps: list[str] = field(default_factory=list)
     actions: list[PlanAction] = field(default_factory=list)
 
     def is_noop(self, stream_count: int) -> bool:

--- a/src/vid_cleaner/models/conversion_plan.py
+++ b/src/vid_cleaner/models/conversion_plan.py
@@ -39,6 +39,21 @@ class OutputStream:
 
 
 @dataclass
+class PlanAction:
+    """One cleaning operation the plan considered, for user-facing reporting.
+
+    Attributes:
+        label (str): Human-readable operation name (e.g. "Downmix to stereo").
+        applied (bool): Whether the operation actually runs in this pass.
+        reason (str | None): Why the operation was skipped, shown only in debug output.
+    """
+
+    label: str
+    applied: bool
+    reason: str | None = None
+
+
+@dataclass
 class ConversionPlan:
     """A composed single-pass ffmpeg conversion for one video file.
 
@@ -51,12 +66,14 @@ class ConversionPlan:
         global_args (list[str]): Output-wide args appended after per-stream options.
         output_suffix (str | None): Container suffix override (e.g. ".webm").
         substeps (list[str]): Result-tree messages describing the applied operations.
+        actions (list[PlanAction]): Cleaning operations the plan considered.
     """
 
     streams: list[OutputStream] = field(default_factory=list)
     global_args: list[str] = field(default_factory=list)
     output_suffix: str | None = None
     substeps: list[str] = field(default_factory=list)
+    actions: list[PlanAction] = field(default_factory=list)
 
     def is_noop(self, stream_count: int) -> bool:
         """Check whether executing this plan would change nothing about the file.

--- a/src/vid_cleaner/models/video_file.py
+++ b/src/vid_cleaner/models/video_file.py
@@ -31,7 +31,7 @@ from vid_cleaner.constants import (
     CodecTypes,
     VideoTrait,
 )
-from vid_cleaner.models.conversion_plan import ConversionPlan, OutputStream
+from vid_cleaner.models.conversion_plan import ConversionPlan, OutputStream, PlanAction
 from vid_cleaner.utils import (
     MediaId,
     find_media_ids,
@@ -455,12 +455,20 @@ class VideoFile:
         video_stream = self._first_video_stream()
         if not video_stream:
             pp.error("No video stream found")
+            plan.actions.append(
+                PlanAction(label="Convert to H.265", applied=False, reason="no video stream")
+            )
             return
 
         if not settings.force and video_stream.codec_name.lower() in H265_CODECS:
             pp.warning(
                 "H265 ENCODE: Video already H.265 or VP9.",
                 details=["Run with `--force` to re-encode.", "Skipping"],
+            )
+            plan.actions.append(
+                PlanAction(
+                    label="Convert to H.265", applied=False, reason="already H.265/VP9; use --force"
+                )
             )
             return
 
@@ -469,6 +477,11 @@ class VideoFile:
         stream_duration = float(self.probe_box.duration or 0) or float(video_stream.duration or 0)
         if not stream_duration:
             pp.error("Could not calculate video duration")
+            plan.actions.append(
+                PlanAction(
+                    label="Convert to H.265", applied=False, reason="could not determine duration"
+                )
+            )
             return
 
         # Convert duration to minutes for bitrate calculation
@@ -505,7 +518,7 @@ class VideoFile:
                 "-bufsize:v:{n}",
                 f"{current_bitrate}k",
             ]
-        plan.substeps.append(f"{SYMBOL_CHECK} Convert to H.265")
+        plan.actions.append(PlanAction(label="Convert to H.265", applied=True))
 
     def _plan_vp9(self, plan: ConversionPlan) -> None:
         """Plan a VP9/WebM conversion, adapting audio and subtitles to the container.
@@ -520,6 +533,9 @@ class VideoFile:
         video_stream = self._first_video_stream()
         if not video_stream:
             pp.error("No video stream found")
+            plan.actions.append(
+                PlanAction(label="Convert to VP9", applied=False, reason="no video stream")
+            )
             return
 
         # Skip re-encoding if already in modern codec unless forced
@@ -528,10 +544,15 @@ class VideoFile:
                 "VP9 ENCODE: Video already H.265 or VP9.",
                 details=["Run with `--force` to re-encode.", "Skipping"],
             )
+            plan.actions.append(
+                PlanAction(
+                    label="Convert to VP9", applied=False, reason="already H.265/VP9; use --force"
+                )
+            )
             return
 
         if Path(settings.out_path).suffix != ".webm":
-            plan.substeps.append(
+            pp.info(
                 f"Converting to VP9, setting output to `{settings.out_path.with_suffix('.webm').name}`"
             )
             settings.out_path = settings.out_path.with_suffix(".webm")
@@ -560,7 +581,7 @@ class VideoFile:
             kept_streams.append(stream)
 
         plan.streams = kept_streams
-        plan.substeps.append(f"{SYMBOL_CHECK} Convert to vp9")
+        plan.actions.append(PlanAction(label="Convert to VP9", applied=True))
 
     def _plan_scale_to_1080p(self, plan: ConversionPlan) -> None:
         """Plan downscaling the video stream to 1080p.
@@ -571,11 +592,16 @@ class VideoFile:
         video_stream = self._first_video_stream()
         if not video_stream:
             pp.error("No video stream found")
+            plan.actions.append(
+                PlanAction(label="Convert to 1080p", applied=False, reason="no video stream")
+            )
             return
 
         # Skip downscaling if video is already 1080p or smaller, unless forced
         if not settings.force and (getattr(video_stream, "width", 0) or 0) <= 1920:  # noqa: PLR2004
-            plan.substeps.append(f"{SYMBOL_CHECK} No convert to 1080p needed")
+            plan.actions.append(
+                PlanAction(label="Convert to 1080p", applied=False, reason="source already ≤1080p")
+            )
             return
 
         # Scale every kept video stream, matching the old `-filter:v scale=...` (no index),
@@ -586,7 +612,7 @@ class VideoFile:
             if video_output.codec == "copy":
                 # Scaling requires an encode; None lets ffmpeg pick the container default
                 video_output.codec = None
-        plan.substeps.append(f"{SYMBOL_CHECK} Convert to 1080p")
+        plan.actions.append(PlanAction(label="Convert to 1080p", applied=True))
 
     def _build_plan(self) -> ConversionPlan:
         """Compose every requested operation into a single-pass conversion plan.

--- a/src/vid_cleaner/models/video_file.py
+++ b/src/vid_cleaner/models/video_file.py
@@ -354,17 +354,24 @@ class VideoFile:
             pp.trace(f"PLAN AUDIO: Remove stream #{stream.index}")
 
         # If every stream would be removed, keep them all to prevent silent video
-        if not streams_to_keep:
+        fallback_triggered = not streams_to_keep
+        if fallback_triggered:
             streams_to_keep = list(self.audio_streams)
 
         dropped = len(self.audio_streams) - len(streams_to_keep)
-        plan.actions.append(
-            PlanAction(
+        if fallback_triggered:
+            action = PlanAction(
+                label="Drop unwanted audio",
+                applied=False,
+                reason="kept all audio to avoid a silent file",
+            )
+        else:
+            action = PlanAction(
                 label="Drop unwanted audio",
                 applied=dropped > 0,
                 reason=None if dropped > 0 else "all audio matches keep languages",
             )
-        )
+        plan.actions.append(action)
 
         # Plan the downmix; forced recreation can request dropping an existing stereo track
         downmix_streams, streams_to_drop, downmix_action = (
@@ -642,11 +649,27 @@ class VideoFile:
                     pp.info(
                         f"Dropping image-based subtitle stream 0:{stream.source_index}; WebM only supports WebVTT"
                     )
+                    self._mark_subtitles_dropped(plan)
                     continue
             kept_streams.append(stream)
 
         plan.streams = kept_streams
         plan.actions.append(PlanAction(label="Convert to VP9", applied=True))
+
+    @staticmethod
+    def _mark_subtitles_dropped(plan: ConversionPlan) -> None:
+        """Correct the "Drop unwanted subtitles" action once VP9 drops an image subtitle.
+
+        `_plan_subtitle_streams` runs before VP9 adaptation and may have recorded
+        applied=False; a VP9-only drop makes that earlier outcome untruthful.
+
+        Args:
+            plan (ConversionPlan): The plan whose recorded action is updated in place.
+        """
+        for action in plan.actions:
+            if action.label == "Drop unwanted subtitles":
+                action.applied = True
+                action.reason = None
 
     def _plan_scale_to_1080p(self, plan: ConversionPlan) -> None:
         """Plan downscaling the video stream to 1080p.

--- a/src/vid_cleaner/models/video_file.py
+++ b/src/vid_cleaner/models/video_file.py
@@ -17,6 +17,7 @@ from vid_cleaner import settings
 from vid_cleaner.constants import (
     COMMENTARY_STREAM_TITLE_REGEX,
     DOWNMIX_STEREO_FILTER,
+    DROP_SUBTITLES_LABEL,
     EXCLUDED_VIDEO_CODECS,
     FFMPEG_APPEND,
     FFMPEG_PREPEND,
@@ -477,7 +478,7 @@ class VideoFile:
         else:
             reason = "no unwanted subtitles"
         plan.actions.append(
-            PlanAction(label="Drop unwanted subtitles", applied=dropped > 0, reason=reason)
+            PlanAction(label=DROP_SUBTITLES_LABEL, applied=dropped > 0, reason=reason)
         )
 
         return keep
@@ -667,7 +668,7 @@ class VideoFile:
             plan (ConversionPlan): The plan whose recorded action is updated in place.
         """
         for action in plan.actions:
-            if action.label == "Drop unwanted subtitles":
+            if action.label == DROP_SUBTITLES_LABEL:
                 action.applied = True
                 action.reason = None
 

--- a/src/vid_cleaner/models/video_file.py
+++ b/src/vid_cleaner/models/video_file.py
@@ -236,7 +236,9 @@ class VideoFile:
         ]
 
     @staticmethod
-    def _plan_downmix(streams: list[Box]) -> tuple[list[OutputStream], list[Box]]:
+    def _plan_downmix(
+        streams: list[Box],
+    ) -> tuple[list[OutputStream], list[Box], PlanAction | None]:
         """Plan a downmix of the simplest surround bed to a dialogue-forward stereo track.
 
         Skip the work when a non-commentary stereo mix already exists, unless
@@ -248,8 +250,10 @@ class VideoFile:
             streams (list[Box]): Audio streams that would otherwise be kept.
 
         Returns:
-            tuple[list[OutputStream], list[Box]]: The planned downmix output streams and
-                the existing streams the caller must not map.
+            tuple[list[OutputStream], list[Box], PlanAction | None]: The planned downmix
+                output streams, the existing streams the caller must not map, and the
+                recorded action (always populated; callers only invoke this method when
+                `settings.downmix_stereo` is set).
         """
         downmix_streams: list[OutputStream] = []
         streams_to_drop: list[Box] = []
@@ -277,12 +281,20 @@ class VideoFile:
                 pp.info(
                     "Stereo track already exists; skipping downmix. Use --force to recreate it."
                 )
-                return downmix_streams, streams_to_drop
+                action = PlanAction(
+                    label="Downmix to stereo",
+                    applied=False,
+                    reason="stereo track already exists; use --force",
+                )
+                return downmix_streams, streams_to_drop, action
             if not surround_source:
                 pp.info(
                     "No surround source to recreate stereo from; keeping existing stereo track."
                 )
-                return downmix_streams, streams_to_drop
+                action = PlanAction(
+                    label="Downmix to stereo", applied=False, reason="no surround source to downmix"
+                )
+                return downmix_streams, streams_to_drop, action
             # Forced recreation: drop the existing stereo mix and rebuild it from the surround bed
             streams_to_drop = existing_stereo
 
@@ -297,10 +309,19 @@ class VideoFile:
             )
             for stream in surround_source
         ]
-        return downmix_streams, streams_to_drop
+        action = PlanAction(
+            label="Downmix to stereo",
+            applied=bool(downmix_streams),
+            reason=None if downmix_streams else "no surround source to downmix",
+        )
+        return downmix_streams, streams_to_drop, action
 
-    def _plan_audio_streams(self) -> list[OutputStream]:
+    def _plan_audio_streams(self, plan: ConversionPlan) -> list[OutputStream]:
         """Plan audio streams to keep, honoring language, commentary, and downmix settings.
+
+        Args:
+            plan (ConversionPlan): The plan whose actions record drop-audio and downmix
+                outcomes.
 
         Returns:
             list[OutputStream]: Copy-mapped kept audio followed by any planned downmix.
@@ -335,10 +356,21 @@ class VideoFile:
         if not streams_to_keep:
             streams_to_keep = list(self.audio_streams)
 
-        # Plan the downmix; forced recreation can request dropping an existing stereo track
-        downmix_streams, streams_to_drop = (
-            self._plan_downmix(streams_to_keep) if settings.downmix_stereo else ([], [])
+        dropped = len(self.audio_streams) - len(streams_to_keep)
+        plan.actions.append(
+            PlanAction(
+                label="Drop unwanted audio",
+                applied=dropped > 0,
+                reason=None if dropped > 0 else "all audio matches keep languages",
+            )
         )
+
+        # Plan the downmix; forced recreation can request dropping an existing stereo track
+        downmix_streams, streams_to_drop, downmix_action = (
+            self._plan_downmix(streams_to_keep) if settings.downmix_stereo else ([], [], None)
+        )
+        if downmix_action is not None:
+            plan.actions.append(downmix_action)
 
         drop_indices = {stream.index for stream in streams_to_drop}
         kept = [
@@ -348,8 +380,49 @@ class VideoFile:
         ]
         return kept + downmix_streams
 
-    def _plan_subtitle_streams(self) -> list[OutputStream]:
+    @staticmethod
+    def _should_keep_subtitle(
+        stream: Box, langs: list[Lang], original_language: Lang | None
+    ) -> bool:
+        """Decide whether a single subtitle stream matches the user's keep preferences.
+
+        Args:
+            stream (Box): The subtitle stream under evaluation.
+            langs (list[Lang]): Languages the user wants to keep.
+            original_language (Lang | None): The file's original audio language, or
+                None when `settings.drop_local_subs` made it unnecessary to look up.
+
+        Returns:
+            bool: True when the stream should be mapped into the output.
+        """
+        if settings.keep_all_subtitles:
+            return True
+
+        if not stream.language:
+            return False
+
+        # Keep undefined language streams and streams matching user preferences
+        # This ensures we don't accidentally remove important subtitles
+        if settings.keep_local_subtitles and (
+            stream.language.lower() == "und" or Lang(stream.language) in langs
+        ):
+            return True
+
+        # Keep subtitles in user's languages when original audio differs
+        # This ensures subtitles are available when needed for translation
+        return bool(
+            not settings.drop_local_subs
+            and langs
+            and original_language not in langs
+            and (stream.language.lower() == "und" or Lang(stream.language) in langs)
+        )
+
+    def _plan_subtitle_streams(self, plan: ConversionPlan) -> list[OutputStream]:
         """Plan subtitle streams to keep based on language preferences.
+
+        Args:
+            plan (ConversionPlan): The plan whose actions record the drop-subtitles
+                outcome.
 
         Returns:
             list[OutputStream]: Copy-mapped kept subtitle streams.
@@ -360,53 +433,44 @@ class VideoFile:
 
         # Only look up original language if we're not explicitly dropping local subs
         # This avoids unnecessary API calls
-        if not settings.drop_local_subs:
-            original_language = self._find_original_language()
+        original_language = None if settings.drop_local_subs else self._find_original_language()
 
-        # Early return if no subtitle streams should be kept based on settings
-        if (
+        # Skip evaluating streams entirely when settings drop every local subtitle;
+        # a single return path below still records the drop-subtitles action.
+        drop_all_local = (
             not settings.keep_all_subtitles
             and not settings.keep_local_subtitles
             and settings.drop_local_subs
-        ):
-            return keep
+        )
 
-        for stream in self.subtitle_streams:
-            # Remove commentary/SDH/description tracks unless explicitly kept
-            # These are typically supplementary and take up extra space
-            if not settings.keep_commentary and self._is_commentary_stream(stream):
-                pp.trace(rf"PLAN SUBTITLES: Remove stream #{stream.index} [commentary]")
-                continue
+        if not drop_all_local:
+            for stream in self.subtitle_streams:
+                # Remove commentary/SDH/description tracks unless explicitly kept
+                # These are typically supplementary and take up extra space
+                if not settings.keep_commentary and self._is_commentary_stream(stream):
+                    pp.trace(rf"PLAN SUBTITLES: Remove stream #{stream.index} [commentary]")
+                    continue
 
-            if settings.keep_all_subtitles:
-                keep.append(OutputStream(source_index=stream.index, codec_type=CodecTypes.SUBTITLE))
-                continue
-
-            if stream.language:
-                # Keep undefined language streams and streams matching user preferences
-                # This ensures we don't accidentally remove important subtitles
-                if settings.keep_local_subtitles and (
-                    stream.language.lower() == "und" or Lang(stream.language) in langs
-                ):
+                if self._should_keep_subtitle(stream, langs, original_language):
                     keep.append(
                         OutputStream(source_index=stream.index, codec_type=CodecTypes.SUBTITLE)
                     )
                     continue
 
-                # Keep subtitles in user's languages when original audio differs
-                # This ensures subtitles are available when needed for translation
-                if (
-                    not settings.drop_local_subs
-                    and langs
-                    and original_language not in langs
-                    and (stream.language.lower() == "und" or Lang(stream.language) in langs)
-                ):
-                    keep.append(
-                        OutputStream(source_index=stream.index, codec_type=CodecTypes.SUBTITLE)
-                    )
-                    continue
+                pp.trace(f"PLAN SUBTITLES: Remove stream #{stream.index}")
 
-            pp.trace(f"PLAN SUBTITLES: Remove stream #{stream.index}")
+        dropped = len(self.subtitle_streams) - len(keep)
+        if dropped > 0:
+            reason: str | None = None
+        elif not self.subtitle_streams:
+            reason = "no subtitles to drop"
+        elif settings.keep_all_subtitles:
+            reason = "--keep-all-subtitles set"
+        else:
+            reason = "no unwanted subtitles"
+        plan.actions.append(
+            PlanAction(label="Drop unwanted subtitles", applied=dropped > 0, reason=reason)
+        )
 
         return keep
 
@@ -621,9 +685,10 @@ class VideoFile:
             ConversionPlan: The composed plan, ready to build one ffmpeg command.
         """
         plan = ConversionPlan()
-        plan.streams = (
-            self._plan_video_streams() + self._plan_audio_streams() + self._plan_subtitle_streams()
-        )
+        video = self._plan_video_streams()
+        audio = self._plan_audio_streams(plan)
+        subtitles = self._plan_subtitle_streams(plan)
+        plan.streams = video + audio + subtitles
 
         # Codec planners run before the scale planner so scaling only falls back to the
         # container default encoder when no explicit codec was requested.

--- a/src/vid_cleaner/models/video_file.py
+++ b/src/vid_cleaner/models/video_file.py
@@ -40,6 +40,7 @@ from vid_cleaner.utils import (
     query_sonarr,
     query_tmdb,
     query_tmdb_by_id,
+    render_operations,
     run_ffprobe,
 )
 
@@ -701,16 +702,17 @@ class VideoFile:
 
         return plan
 
-    def clean(self) -> list[str]:
+    def clean(self) -> list[PlanAction]:
         """Apply every requested cleaning operation in a single ffmpeg pass.
 
         Compose stream selection, reordering, downmix, scaling, and codec conversion
         into one command so the file is decoded and written exactly once. Skip ffmpeg
-        entirely when the plan would change nothing.
+        entirely when the plan would change nothing. Report the operations considered,
+        up front, before the ffmpeg progress bar starts.
 
         Returns:
-            list[str]: Substep messages describing the outcome, for the caller to
-                display. Empty on a dry run, since the command is previewed instead.
+            list[PlanAction]: The plan's operations, applied or skipped, for the
+                caller to inspect.
 
         Raises:
             cappa.Exit: If the file has no video or no audio streams.
@@ -725,38 +727,26 @@ class VideoFile:
         plan = self._build_plan()
 
         needs_reorder = self._need_stream_reorder()
-        substeps = [
-            f"{SYMBOL_CHECK} Reorder streams"
-            if needs_reorder
-            else f"{SYMBOL_CHECK} No streams to reorder"
-        ]
-
-        if plan.is_noop(stream_count=len(self.all_streams)) and not needs_reorder:
-            return [*substeps, f"{SYMBOL_CHECK} No streams to process"]
-
-        title_flags = []
-        title_flags.append("drop original audio") if settings.drop_original_audio else None
-        title_flags.append("keep commentary") if settings.keep_commentary else None
-        title_flags.append("downmix to stereo") if settings.downmix_stereo else None
-
-        if any(stream.codec_type == CodecTypes.SUBTITLE for stream in plan.streams):
-            title_flags.append(
-                "keep subtitles",
-            ) if settings.keep_all_subtitles else title_flags.append("drop unwanted subtitles")
-            title_flags.append("keep local subtitles") if settings.keep_local_subtitles else None
-            title_flags.append("drop local subtitles") if settings.drop_local_subs else None
-
-        title = f"Process file ({', '.join(title_flags)})" if title_flags else "Process file"
-
-        run_result = self._run_ffmpeg(
-            plan.build_command(), title=title, suffix=plan.output_suffix, step="clean"
+        plan.actions.insert(
+            0,
+            PlanAction(
+                label="Reorder streams",
+                applied=needs_reorder,
+                reason=None if needs_reorder else "streams already in order",
+            ),
         )
-        if not run_result:  # Dry run previews the command instead of executing it
-            return []
 
-        substeps.append(f"{SYMBOL_CHECK} {title}")
-        substeps.extend(plan.substeps)
-        return substeps
+        debug = int(settings.get("verbosity", 0) or 0) >= 1
+        render_operations(plan.actions, debug=debug)
+
+        # Nothing to encode: the up-front render already reported "No changes needed".
+        if plan.is_noop(stream_count=len(self.all_streams)) and not needs_reorder:
+            return plan.actions
+
+        self._run_ffmpeg(
+            plan.build_command(), title="Processing", suffix=plan.output_suffix, step="clean"
+        )
+        return plan.actions
 
     def _language_for(self, media_id: MediaId) -> Lang | None:
         """Resolve a single media ID to the content's original language.

--- a/src/vid_cleaner/utils/__init__.py
+++ b/src/vid_cleaner/utils/__init__.py
@@ -1,7 +1,7 @@
 """Shared utilities."""
 
 from .api_utils import query_radarr, query_sonarr, query_tmdb, query_tmdb_by_id
-from .console import render_substeps
+from .console import render_operations, render_substeps
 from .ffmpeg_utils import channels_to_layout, get_probe_as_box, run_ffprobe
 from .media_ids import MediaId, find_media_ids
 
@@ -26,6 +26,7 @@ __all__ = [
     "query_sonarr",
     "query_tmdb",
     "query_tmdb_by_id",
+    "render_operations",
     "render_substeps",
     "resolve_out_path_override",
     "run_ffprobe",

--- a/src/vid_cleaner/utils/console.py
+++ b/src/vid_cleaner/utils/console.py
@@ -1,9 +1,16 @@
 """Console output helpers."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from nclutils import pp
 from rich.text import Text
 
 from vid_cleaner.constants import SYMBOL_CHECK, SYMBOL_CROSS, TREE_BRANCH, TREE_LAST
+
+if TYPE_CHECKING:
+    from vid_cleaner.models.conversion_plan import PlanAction
 
 
 def render_substeps(messages: list[str]) -> None:
@@ -23,12 +30,13 @@ def render_substeps(messages: list[str]) -> None:
         pp.info(line)
 
 
-def render_operations(actions: list, *, debug: bool) -> None:
+def render_operations(actions: list[PlanAction], *, debug: bool) -> None:
     """Render the cleaning operations for a file as a tree beneath its name.
 
     Print the truthful operation list up front, before the ffmpeg progress bar. In
     normal mode only operations that actually run are shown; in debug mode every
     requested operation is shown, with skipped ones marked and annotated with a reason.
+    When no operations are visible, render a single "No changes needed" line.
 
     Args:
         actions: The plan's operations, in display order.

--- a/src/vid_cleaner/utils/console.py
+++ b/src/vid_cleaner/utils/console.py
@@ -3,7 +3,7 @@
 from nclutils import pp
 from rich.text import Text
 
-from vid_cleaner.constants import TREE_BRANCH, TREE_LAST
+from vid_cleaner.constants import SYMBOL_CHECK, SYMBOL_CROSS, TREE_BRANCH, TREE_LAST
 
 
 def render_substeps(messages: list[str]) -> None:
@@ -20,4 +20,36 @@ def render_substeps(messages: list[str]) -> None:
         # `sub.pipe` is nclutils' dim connector style, matching its own Step sub-items.
         line = Text.from_markup(f"  [sub.pipe]{connector}[/] ")
         line.append(message)
+        pp.info(line)
+
+
+def render_operations(actions: list, *, debug: bool) -> None:
+    """Render the cleaning operations for a file as a tree beneath its name.
+
+    Print the truthful operation list up front, before the ffmpeg progress bar. In
+    normal mode only operations that actually run are shown; in debug mode every
+    requested operation is shown, with skipped ones marked and annotated with a reason.
+
+    Args:
+        actions: The plan's operations, in display order.
+        debug: When True, also show skipped operations with their reason.
+    """
+    visible = actions if debug else [action for action in actions if action.applied]
+
+    lines: list[tuple[str, bool]] = []
+    if not visible:
+        lines.append(("No changes needed", False))
+    else:
+        for action in visible:
+            if action.applied:
+                lines.append((f"{SYMBOL_CHECK} {action.label}", False))
+            else:
+                suffix = f"  ({action.reason})" if action.reason else ""
+                lines.append((f"{SYMBOL_CROSS} {action.label}{suffix}", True))
+
+    last_index = len(lines) - 1
+    for index, (message, dim) in enumerate(lines):
+        connector = TREE_LAST if index == last_index else TREE_BRANCH
+        line = Text.from_markup(f"  [sub.pipe]{connector}[/] ")
+        line.append(message, style="dim" if dim else "")
         pp.info(line)

--- a/src/vid_cleaner/utils/console.py
+++ b/src/vid_cleaner/utils/console.py
@@ -13,21 +13,35 @@ if TYPE_CHECKING:
     from vid_cleaner.models.conversion_plan import PlanAction
 
 
+def _render_tree(lines: list[tuple[str, str]]) -> None:
+    """Print styled lines beneath the current video as a faked ``pp`` sub-item tree.
+
+    A real ``pp.step`` spinner recomputes the connector on each live refresh, but its
+    live display cannot coexist with the live ffmpeg/copy progress bars, so the tree is
+    faked here: the whole list is rendered at once so the final child closes with ``└─``.
+
+    Args:
+        lines: ``(message, style)`` pairs in display order; ``style`` is a Rich style
+            applied to the message text (empty string for no styling).
+    """
+    last_index = len(lines) - 1
+    for index, (message, style) in enumerate(lines):
+        connector = TREE_LAST if index == last_index else TREE_BRANCH
+        # `sub.pipe` is nclutils' dim connector style, matching its own Step sub-items.
+        line = Text.from_markup(f"  [sub.pipe]{connector}[/] ")
+        line.append(message, style=style)
+        pp.info(line)
+
+
 def render_substeps(messages: list[str]) -> None:
     """Render operation outcomes as a tree of children styled like ``pp`` sub-items.
 
-    Keep presentation in the CLI layer: the model returns these strings without emitting them, and the caller renders the whole list at once so the final child can close with ``└─``. A real ``pp.step`` spinner recomputes that connector on each live refresh, but its live display cannot coexist with the live ffmpeg/copy progress bars, so the tree is faked here instead.
+    Keep presentation in the CLI layer: the model returns these strings without emitting them, and the caller renders the whole list at once so the final child can close with ``└─``.
 
     Args:
         messages: Outcome lines to display beneath the current video, in order.
     """
-    last_index = len(messages) - 1
-    for index, message in enumerate(messages):
-        connector = TREE_LAST if index == last_index else TREE_BRANCH
-        # `sub.pipe` is nclutils' dim connector style, matching its own Step sub-items.
-        line = Text.from_markup(f"  [sub.pipe]{connector}[/] ")
-        line.append(message)
-        pp.info(line)
+    _render_tree([(message, "") for message in messages])
 
 
 def render_operations(actions: list[PlanAction], *, debug: bool) -> None:
@@ -44,20 +58,15 @@ def render_operations(actions: list[PlanAction], *, debug: bool) -> None:
     """
     visible = actions if debug else [action for action in actions if action.applied]
 
-    lines: list[tuple[str, bool]] = []
+    lines: list[tuple[str, str]] = []
     if not visible:
-        lines.append(("No changes needed", False))
+        lines.append(("No changes needed", ""))
     else:
         for action in visible:
             if action.applied:
-                lines.append((f"{SYMBOL_CHECK} {action.label}", False))
+                lines.append((f"{SYMBOL_CHECK} {action.label}", ""))
             else:
                 suffix = f"  ({action.reason})" if action.reason else ""
-                lines.append((f"{SYMBOL_CROSS} {action.label}{suffix}", True))
+                lines.append((f"{SYMBOL_CROSS} {action.label}{suffix}", "dim"))
 
-    last_index = len(lines) - 1
-    for index, (message, dim) in enumerate(lines):
-        connector = TREE_LAST if index == last_index else TREE_BRANCH
-        line = Text.from_markup(f"  [sub.pipe]{connector}[/] ")
-        line.append(message, style="dim" if dim else "")
-        pp.info(line)
+    _render_tree(lines)

--- a/src/vid_cleaner/vidcleaner.py
+++ b/src/vid_cleaner/vidcleaner.py
@@ -57,6 +57,7 @@ def config_subcommand(vidcleaner: VidCleaner) -> None:
         "out_path": getattr(vidcleaner.command, "out", None),
         "overwrite": getattr(vidcleaner.command, "overwrite", False),
         "subcommand": vidcleaner.command.__class__.__name__.lower(),
+        "verbosity": nllog_level,
         "video_1080": getattr(vidcleaner.command, "video_1080", False),
         "vp9": getattr(vidcleaner.command, "vp9", False),
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,23 @@ import pytest
 from box import Box
 from rich.console import Console
 
+from vid_cleaner import settings
 from vid_cleaner.utils import get_probe_as_box
 
 console = Console()
+
+
+@pytest.fixture(autouse=True)
+def _reset_verbosity():
+    """Reset settings.verbosity to its default before and after every test.
+
+    `settings` is a process-wide singleton, so a test that persists a CLI
+    verbosity flag (e.g. via `config_subcommand`) would otherwise leak that
+    value into unrelated tests run later in the same session.
+    """
+    settings.update({"verbosity": 0})
+    yield
+    settings.update({"verbosity": 0})
 
 
 @pytest.fixture

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -797,8 +797,9 @@ def test_clean_multiple_files_overwrite_each_in_place(
 def test_clean_renders_completed_steps_on_error(
     mocker, mock_ffprobe_box, mock_ffmpeg, capsys, mock_video_path
 ) -> None:
-    """Verify steps completed by a successful clean() are still rendered when the write fails."""
-    # Given: a clean() that succeeds and produces substeps, but the final write raises
+    """Verify operations render up front even when the later write step raises."""
+    # Given: operations render up front inside clean(), before the write step, so a
+    # failing write can't hide what already completed
     args = ["clean", "-vv", "--h265", str(mock_video_path)]
     mocker.patch(
         "vid_cleaner.models.video_file.get_probe_as_box",

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -76,43 +76,43 @@ def test_clean_out_with_multiple_files_errors(debug, tmp_path, capsys) -> None:
         pytest.param(
             [],
             ["-map 0:0 -map 0:1 -map 0:2 -map 0:4"],
-            "✔ Process file",
+            ["✔ Drop unwanted audio", "✔ Drop unwanted subtitles"],
             id="Defaults (only keep local audio,no commentary)",
         ),
         pytest.param(
             ["--downmix"],
             ["-map 0:0 -map 0:1 -map 0:2 -map 0:4"],
-            "✔ Process file (downmix to stereo)",
+            ["✖ Downmix to stereo  (stereo track already exists; use --force)"],
             id="Don't convert audio to stereo when stereo exists",
         ),
         pytest.param(
             ["--keep-commentary"],
             ["-map 0:0 -map 0:1 -map 0:2 -map 0:4 -map 0:5"],
-            "✔ Process file (keep commentary)",
+            ["✔ Drop unwanted audio"],
             id="Keep commentary",
         ),
         pytest.param(
             ["--drop-original"],
             ["-map 0:0 -map 0:1 -map 0:2 -map 0:4"],
-            "✔ Process file (drop original audio)",
+            ["✔ Drop unwanted audio"],
             id="Keep local language from config even when dropped",
         ),
         pytest.param(
             ["--langs", "fr,es"],
             ["-map 0:0 -map 0:1 -map 0:2 -map 0:3 -map 0:4 -map 0:8"],
-            "✔ Process file (drop unwanted subtitles)",
+            ["✔ Drop unwanted subtitles"],
             id="Keep specified languages",
         ),
         pytest.param(
             ["--keep-subs"],
             ["-map 0:0 -map 0:1 -map 0:2 -map 0:4 -map 0:6 -map 0:7 -map 0:8"],
-            "✔ Process file (keep subtitles)",
+            ["✖ Drop unwanted subtitles  (--keep-all-subtitles set)"],
             id="Keep all subtitles",
         ),
         pytest.param(
             ["--keep-local-subs"],
             ["-map 0:0 -map 0:1 -map 0:2 -map 0:4 -map 0:6"],
-            "✔ Process file (drop unwanted subtitles, keep local subtitles)",
+            ["✔ Drop unwanted subtitles"],
             id="Keep local subtitles",
         ),
     ],
@@ -157,10 +157,12 @@ def test_stream_processing(
     for fragment in command_expected:
         assert fragment in command
 
-    # And: Success messages are displayed
+    # And: Success messages are displayed. The fixture's video stream is already first, so
+    # under -vv the reorder action shows skipped rather than absent.
     assert exc_info.value.code == 0
-    assert "✔ No streams to reorder" in output
-    assert process_output in output
+    assert "✖ Reorder streams  (streams already in order)" in output
+    for fragment in process_output:
+        assert fragment in output
     assert "cleaned_video.mkv" in output
 
 
@@ -208,7 +210,7 @@ def test_clean_video_foreign_language_keeps_und_subtitle(
     assert "-map 0:6" in command
     assert "-map 0:7" in command
     assert "-map 0:8" not in command
-    assert "✔ No streams to reorder" in output
+    assert "✖ Reorder streams  (streams already in order)" in output
     assert "cleaned_video.mkv" in output
 
 
@@ -218,19 +220,19 @@ def test_clean_video_foreign_language_keeps_und_subtitle(
         pytest.param(
             [],
             ["-map 0:0 -map 0:1 -map 0:2 -map 0:3 -map 0:4 -map 0:6"],
-            "✔ Process file (drop unwanted subtitles)",
+            ["✔ Drop unwanted subtitles"],
             id="Defaults keep local and original audio, local subs",
         ),
         pytest.param(
             ["--drop-original"],
             ["-map 0:0 -map 0:1 -map 0:2 -map 0:4 -map 0:6"],
-            "✔ Process file (drop original audio, drop unwanted subtitles)",
+            ["✔ Drop unwanted audio", "✔ Drop unwanted subtitles"],
             id="Drop original audio (keeps local audio)",
         ),
         pytest.param(
             ["--drop-local-subs"],
             ["-map 0:0 -map 0:1 -map 0:2 -map 0:3 -map 0:4"],
-            "✔ Process file",
+            ["✔ Drop unwanted subtitles"],
             id="Drop local subs",
         ),
     ],
@@ -273,12 +275,14 @@ def test_clean_video_foreign_language(
     args, _ = mock_ffmpeg.call_args
     command = " ".join(args[0])
 
-    # AND verify the command output indicates successful processing
+    # AND verify the command output indicates successful processing. The fixture's video
+    # stream is already first, so under -vv the reorder action shows skipped rather than absent.
     assert exc_info.value.code == 0
     for fragment in command_expected:
         assert fragment in command
-    assert "✔ No streams to reorder" in output
-    assert process_output in output
+    assert "✖ Reorder streams  (streams already in order)" in output
+    for fragment in process_output:
+        assert fragment in output
     assert "cleaned_video.mkv" in output
 
 
@@ -288,7 +292,7 @@ def test_clean_video_foreign_language(
         pytest.param(
             [],
             ["-map 0:0 -map 0:1 -map 0:2"],
-            "✔ Process file",
+            "✔ Drop unwanted audio",
             id="Defaults, drops commentary",
         ),
         pytest.param(
@@ -301,7 +305,7 @@ def test_clean_video_foreign_language(
                 "-ac:a:2 2 -b:a:2 256k -ar:a:2 48000",
                 "-metadata:s:a:2 title=2.0",
             ],
-            "✔ Process file (downmix to stereo)",
+            "✔ Downmix to stereo",
             id="Defaults",
         ),
     ],
@@ -346,9 +350,10 @@ def test_clean_video_downmix(
     for fragment in command_expected:
         assert fragment in command
 
-    # And: Success messages are displayed
+    # And: Success messages are displayed. The fixture's video stream is already first, so
+    # under -vv the reorder action shows skipped rather than absent.
     assert exc_info.value.code == 0
-    assert "✔ No streams to reorder" in output
+    assert "✖ Reorder streams  (streams already in order)" in output
     assert process_output in output
     assert "cleaned_video.mkv" in output
 
@@ -392,7 +397,7 @@ def test_clean_video_downmix_stereo_commentary_kept(
     # And: The commentary track is kept and the file is processed
     assert exc_info.value.code == 0
     assert "-map 0:2" in command
-    assert "✔ Process file (downmix to stereo)" in output
+    assert "✔ Downmix to stereo" in output
 
 
 def test_clean_video_downmix_unmapped_channel_count(
@@ -420,10 +425,12 @@ def test_clean_video_downmix_unmapped_channel_count(
     with pytest.raises(cappa.Exit) as exc_info:
         cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
 
-    # Then: It completes successfully without raising an unexpected error
+    # Then: It completes successfully without raising an unexpected error. Under -vv every
+    # skipped operation is shown (none applied), not the normal-mode "No changes needed" line.
     assert exc_info.value.code == 0
     output = capsys.readouterr().out
-    assert "No streams to process" in output
+    assert "✖ Reorder streams  (streams already in order)" in output
+    assert "✖ Downmix to stereo  (no surround source to downmix)" in output
 
 
 def test_clean_video_downmix_dialogue_forward_filter(
@@ -497,7 +504,7 @@ def test_clean_video_downmix_atmos(
     assert "-ac:a:1 2" in command
     assert "pan=stereo|FL=0.8*FC" in command
     assert exc_info.value.code == 0
-    assert "✔ Process file (downmix to stereo)" in output
+    assert "✔ Downmix to stereo" in output
 
 
 def test_clean_video_downmix_does_not_clobber_kept_stream(
@@ -566,12 +573,11 @@ def test_clean_reorganize_streams(
     assert exc_info.value.code == 0
     assert "-map 0:2 -map 0:1 -map 0:3" in command
     assert "✔ Reorder streams" in output
-    assert "✔ Process file" in output
     assert "cleaned_video.mkv" in output
 
 
 @pytest.mark.parametrize(
-    ("args", "command_expected"),
+    ("args", "command_expected", "conversion_output"),
     [
         pytest.param(
             ["--h265"],
@@ -583,6 +589,7 @@ def test_clean_reorganize_streams(
                 "-c:a:1 copy",
                 "-c:a:2 copy",
             ],
+            "✔ Convert to H.265",
             id="Convert to h265",
         ),
         pytest.param(
@@ -594,6 +601,7 @@ def test_clean_reorganize_streams(
                 "-c:a:0 libvorbis",
                 "-dn -map_chapters -1",
             ],
+            "✔ Convert to VP9",
             id="Convert to vp9",
         ),
     ],
@@ -608,6 +616,7 @@ def test_convert_video(
     debug,
     args,
     command_expected,
+    conversion_output,
 ):
     """Verify codec conversion happens in the same single ffmpeg pass as stream selection."""
     # Given: reference.json probe data and a conversion flag
@@ -629,6 +638,7 @@ def test_convert_video(
         cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
 
     output = capsys.readouterr().out
+    # debug(output, "output")
 
     # Then: ffmpeg runs exactly once with selection and conversion combined
     mock_ffmpeg.assert_called_once()
@@ -637,12 +647,11 @@ def test_convert_video(
     for fragment in command_expected:
         assert fragment in command
 
-    # And: the result tree itemizes the conversion. Per-operation itemization (e.g.
-    # "Convert to H.265") now lives on plan.actions; rendering it in the CLI tree is
-    # wired up in a later task (render_operations is not yet called from clean()).
+    # And: the result tree itemizes the conversion, proving the codec change ran alongside
+    # stream selection in the same pass
     assert exc_info.value.code == 0
-    assert "✔ No streams to reorder" in output
-    assert "✔ Process file" in output
+    assert "✖ Reorder streams  (streams already in order)" in output
+    assert conversion_output in output
     if "--vp9" in args:
         assert "Converting to VP9, setting output to `test_video.webm`" in output
 
@@ -743,11 +752,13 @@ def test_clean_renders_completed_steps_on_error(
     with pytest.raises(RuntimeError):
         cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
 
-    # Then: the substeps produced by the successful clean() are still rendered, proving
-    # the `finally: render_substeps(substeps)` path in main() actually renders completed work
+    # Then: the operations render up front, before the failing write, proving the CLI
+    # reports what actually happened even when `write_output()` raises. reference.json's
+    # video stream is already first, so reorder is skipped and H.265 conversion is the
+    # operation that proves clean() ran to completion.
     output = capsys.readouterr().out
-    assert "✔ Process file" in output
-    assert "✔ No streams to reorder" in output
+    assert "✔ Convert to H.265" in output
+    assert "✖ Reorder streams  (streams already in order)" in output
 
 
 def test_clean_video_downmix_skip_when_stereo_exists(
@@ -827,7 +838,7 @@ def test_clean_video_downmix_force_recreates_stereo(
     # reference.json's English subtitle matches langs_to_keep and the original language,
     # so it is dropped rather than kept, and the title carries no subtitle flag
     assert "-map 0:6" not in command
-    assert "✔ Process file (downmix to stereo)" in output
+    assert "✔ Downmix to stereo" in output
 
 
 def test_clean_video_downmix_force_recreates_from_multiple_stereo(
@@ -868,7 +879,7 @@ def test_clean_video_downmix_force_recreates_from_multiple_stereo(
     assert "-map 0:1 -map 0:1" in command
     assert "-c:a:1 aac" in command
     assert "-ac:a:1 2 -b:a:1 256k" in command
-    assert "✔ Process file (downmix to stereo)" in output
+    assert "✔ Downmix to stereo" in output
 
 
 def test_clean_video_downmix_force_no_surround_keeps_stereo(
@@ -898,10 +909,12 @@ def test_clean_video_downmix_force_no_surround_keeps_stereo(
 
     output = capsys.readouterr().out
 
-    # Then: The stereo track is kept (all streams pass through) and the user is notified
+    # Then: The stereo track is kept (all streams pass through) and the user is notified.
+    # Under -vv every skipped operation is shown (none applied), including the downmix
+    # itself, rather than the normal-mode "No changes needed" line.
     assert exc_info.value.code == 0
     assert "No surround source to recreate stereo" in output
-    assert "No streams to process" in output
+    assert "✖ Downmix to stereo  (no surround source to downmix)" in output
 
 
 def test_clean_video_downmix_force_noop_without_existing_stereo(
@@ -939,7 +952,7 @@ def test_clean_video_downmix_force_noop_without_existing_stereo(
     assert "-c:a:2 aac" in command
     assert "-ac:a:2 2 -b:a:2 256k" in command
     assert "-filter:a:2" in command
-    assert "✔ Process file (downmix to stereo)" in output
+    assert "✔ Downmix to stereo" in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -638,7 +638,6 @@ def test_convert_video(
         cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
 
     output = capsys.readouterr().out
-    # debug(output, "output")
 
     # Then: ffmpeg runs exactly once with selection and conversion combined
     mock_ffmpeg.assert_called_once()

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -571,7 +571,7 @@ def test_clean_reorganize_streams(
 
 
 @pytest.mark.parametrize(
-    ("args", "command_expected", "substep_expected"),
+    ("args", "command_expected"),
     [
         pytest.param(
             ["--h265"],
@@ -583,7 +583,6 @@ def test_clean_reorganize_streams(
                 "-c:a:1 copy",
                 "-c:a:2 copy",
             ],
-            "✔ Convert to H.265",
             id="Convert to h265",
         ),
         pytest.param(
@@ -595,7 +594,6 @@ def test_clean_reorganize_streams(
                 "-c:a:0 libvorbis",
                 "-dn -map_chapters -1",
             ],
-            "✔ Convert to vp9",
             id="Convert to vp9",
         ),
     ],
@@ -610,7 +608,6 @@ def test_convert_video(
     debug,
     args,
     command_expected,
-    substep_expected,
 ):
     """Verify codec conversion happens in the same single ffmpeg pass as stream selection."""
     # Given: reference.json probe data and a conversion flag
@@ -640,11 +637,12 @@ def test_convert_video(
     for fragment in command_expected:
         assert fragment in command
 
-    # And: the result tree itemizes the conversion
+    # And: the result tree itemizes the conversion. Per-operation itemization (e.g.
+    # "Convert to H.265") now lives on plan.actions; rendering it in the CLI tree is
+    # wired up in a later task (render_operations is not yet called from clean()).
     assert exc_info.value.code == 0
     assert "✔ No streams to reorder" in output
     assert "✔ Process file" in output
-    assert substep_expected in output
     if "--vp9" in args:
         assert "Converting to VP9, setting output to `test_video.webm`" in output
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -656,6 +656,66 @@ def test_convert_video(
         assert "Converting to VP9, setting output to `test_video.webm`" in output
 
 
+def test_clean_video_h265_skip_shown_in_debug_mode(
+    mocker,
+    mock_ffprobe_box,
+    mock_video_path,
+    capsys,
+    mock_ffmpeg,
+):
+    """Verify -vv reports a skipped --h265 request with its reason when already H.265."""
+    # Given: reference.json rewritten so the video stream is already HEVC
+    args = ["clean", "-vv", "--h265", str(mock_video_path)]
+    box = mock_ffprobe_box("reference.json")
+    box.streams[0].codec_name = "hevc"
+    mocker.patch("vid_cleaner.models.video_file.get_probe_as_box", return_value=box)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+
+    # When: running clean in debug mode with --h265 requested
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: the skipped H.265 conversion is reported with its reason
+    output = capsys.readouterr().out
+    assert exc_info.value.code == 0
+    assert "✖ Convert to H.265  (already H.265/VP9; use --force)" in output
+
+
+def test_clean_video_h265_skip_hidden_in_normal_mode(
+    mocker,
+    mock_ffprobe_box,
+    mock_video_path,
+    capsys,
+    mock_ffmpeg,
+):
+    """Verify normal mode (no -vv) hides the skipped --h265 request and its reason."""
+    # Given: reference.json rewritten so the video stream is already HEVC, and no -vv flag
+    args = ["clean", "--h265", str(mock_video_path)]
+    box = mock_ffprobe_box("reference.json")
+    box.streams[0].codec_name = "hevc"
+    mocker.patch("vid_cleaner.models.video_file.get_probe_as_box", return_value=box)
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+
+    # When: running clean in normal mode with --h265 requested
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: normal mode is genuinely active and the skipped operation is not shown
+    output = capsys.readouterr().out
+    assert exc_info.value.code == 0
+    assert settings.verbosity == 0
+    assert "✖ Convert to H.265" not in output
+    assert "already H.265/VP9; use --force" not in output
+
+
 def test_clean_multiple_files_use_distinct_output_paths(
     mocker,
     mock_ffprobe_box,

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -714,6 +714,8 @@ def test_clean_video_h265_skip_hidden_in_normal_mode(
     assert settings.verbosity == 0
     assert "✖ Convert to H.265" not in output
     assert "already H.265/VP9; use --force" not in output
+    # But verify that rendering actually happened (positive assertion)
+    assert "✔ Drop unwanted audio" in output
 
 
 def test_clean_multiple_files_use_distinct_output_paths(

--- a/tests/test_clean_planning.py
+++ b/tests/test_clean_planning.py
@@ -387,3 +387,175 @@ def test_clean_noop_skips_ffmpeg(make_video, mock_ffmpeg):
     # Then: ffmpeg never runs and the no-op substeps are returned
     mock_ffmpeg.assert_not_called()
     assert any("No streams to process" in step for step in substeps)
+
+
+def test_drop_audio_records_applied_when_streams_dropped(make_video):
+    """Verify drop-audio is applied when language filtering drops audio streams."""
+    # Given: reference.json (french and commentary audio dropped, english kept)
+    video = make_video("reference.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the drop-audio action is applied with no skip reason
+    drop = next(a for a in plan.actions if a.label == "Drop unwanted audio")
+    assert drop.applied is True
+    assert drop.reason is None
+
+
+def test_drop_audio_records_reason_when_nothing_dropped(make_video):
+    """Verify drop-audio records a reason when every audio stream matches the keep languages."""
+    # Given: audio_only.json (single english audio stream, langs_to_keep=["en"])
+    video = make_video("audio_only.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the drop-audio action is skipped with a matching-languages reason
+    drop = next(a for a in plan.actions if a.label == "Drop unwanted audio")
+    assert drop.applied is False
+    assert drop.reason == "all audio matches keep languages"
+
+
+def test_downmix_records_applied_when_planned(make_video):
+    """Verify downmix is applied when a surround source is downmixed to stereo."""
+    # Given: no_stereo.json (no existing stereo mix, 5.1 surround source) with --downmix
+    settings.update({"downmix_stereo": True})
+    video = make_video("no_stereo.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the downmix action is applied with no skip reason
+    downmix = next(a for a in plan.actions if a.label == "Downmix to stereo")
+    assert downmix.applied is True
+    assert downmix.reason is None
+
+
+def test_downmix_records_skip_when_stereo_exists(make_video):
+    """Verify downmix records a skip reason pointing to --force when stereo already exists."""
+    # Given: reference.json (existing non-commentary stereo track) with --downmix, no --force
+    settings.update({"downmix_stereo": True, "force": False})
+    video = make_video("reference.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the downmix action is skipped with a --force reason
+    downmix = next(a for a in plan.actions if a.label == "Downmix to stereo")
+    assert downmix.applied is False
+    assert "use --force" in downmix.reason
+
+
+def test_downmix_records_skip_when_no_surround_source_after_force(make_video):
+    """Verify a forced downmix with no surround source records a no-surround reason."""
+    # Given: stereo_no_surround.json (existing stereo, no surround bed) with --downmix --force
+    settings.update({"downmix_stereo": True, "force": True})
+    video = make_video("stereo_no_surround.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the downmix action is skipped with a no-surround-source reason
+    downmix = next(a for a in plan.actions if a.label == "Downmix to stereo")
+    assert downmix.applied is False
+    assert downmix.reason == "no surround source to downmix"
+
+
+def test_downmix_absent_when_flag_not_set(make_video):
+    """Verify no downmix action is recorded when --downmix is not requested."""
+    # Given: reference.json without --downmix
+    video = make_video("reference.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: no downmix action appears in the plan
+    assert all(a.label != "Downmix to stereo" for a in plan.actions)
+
+
+def test_actions_order_drop_audio_before_downmix(make_video):
+    """Verify the drop-audio action is recorded before the downmix action."""
+    # Given: no_stereo.json with --downmix
+    settings.update({"downmix_stereo": True})
+    video = make_video("no_stereo.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: drop-audio precedes downmix in the recorded actions
+    labels = [a.label for a in plan.actions]
+    assert labels.index("Drop unwanted audio") < labels.index("Downmix to stereo")
+
+
+def test_drop_subtitles_records_applied_when_dropped(make_video):
+    """Verify drop-subtitles is applied when default settings drop every local subtitle."""
+    # Given: reference.json (all subtitles dropped under default settings)
+    video = make_video("reference.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the drop-subtitles action is applied with no skip reason
+    drop = next(a for a in plan.actions if a.label == "Drop unwanted subtitles")
+    assert drop.applied is True
+    assert drop.reason is None
+
+
+def test_drop_subtitles_records_applied_via_early_drop_all_path(make_video):
+    """Verify drop-subtitles is applied when settings drop local subs before evaluation."""
+    # Given: reference.json with --drop-local-subs (skips per-stream evaluation entirely)
+    settings.update({"drop_local_subs": True})
+    video = make_video("reference.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the drop-subtitles action is still recorded exactly once and applied
+    drop_actions = [a for a in plan.actions if a.label == "Drop unwanted subtitles"]
+    assert len(drop_actions) == 1
+    assert drop_actions[0].applied is True
+
+
+def test_drop_subtitles_records_reason_when_no_subtitles(make_video):
+    """Verify drop-subtitles records a reason when the file has no subtitle streams."""
+    # Given: audio_only.json (no subtitle streams)
+    video = make_video("audio_only.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the drop-subtitles action is skipped with a no-subtitles reason
+    drop = next(a for a in plan.actions if a.label == "Drop unwanted subtitles")
+    assert drop.applied is False
+    assert drop.reason == "no subtitles to drop"
+
+
+def test_drop_subtitles_records_reason_when_keep_all_subtitles(make_video):
+    """Verify drop-subtitles records a --keep-all-subtitles reason when nothing is dropped."""
+    # Given: reference.json with --keep-all-subtitles (every subtitle stream kept)
+    settings.update({"keep_all_subtitles": True})
+    video = make_video("reference.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the drop-subtitles action is skipped with a --keep-all-subtitles reason
+    drop = next(a for a in plan.actions if a.label == "Drop unwanted subtitles")
+    assert drop.applied is False
+    assert drop.reason == "--keep-all-subtitles set"
+
+
+def test_drop_subtitles_records_reason_when_no_unwanted(make_video):
+    """Verify drop-subtitles records a generic reason when every subtitle matches local prefs."""
+    # Given: uhd.json (single english subtitle) with --keep-local-subtitles
+    settings.update({"keep_local_subtitles": True})
+    video = make_video("uhd.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the drop-subtitles action is skipped with a no-unwanted-subtitles reason
+    drop = next(a for a in plan.actions if a.label == "Drop unwanted subtitles")
+    assert drop.applied is False
+    assert drop.reason == "no unwanted subtitles"

--- a/tests/test_clean_planning.py
+++ b/tests/test_clean_planning.py
@@ -313,8 +313,12 @@ def test_build_plan_vp9_drops_bitmap_subtitles(make_video):
     # When: building the plan
     plan = video._build_plan()  # noqa: SLF001
 
-    # Then: no subtitle stream survives into the WebM plan
+    # Then: no subtitle stream survives into the WebM plan, and the earlier
+    # "Drop unwanted subtitles" action is corrected to reflect that a drop happened
     assert all(s.codec_type != CodecTypes.SUBTITLE for s in plan.streams)
+    drop_subs = next(a for a in plan.actions if a.label == "Drop unwanted subtitles")
+    assert drop_subs.applied is True
+    assert drop_subs.reason is None
 
 
 def test_build_plan_vp9_downmix_uses_vorbis(make_video):
@@ -415,6 +419,22 @@ def test_drop_audio_records_reason_when_nothing_dropped(make_video):
     drop = next(a for a in plan.actions if a.label == "Drop unwanted audio")
     assert drop.applied is False
     assert drop.reason == "all audio matches keep languages"
+
+
+def test_drop_audio_records_fallback_reason_when_every_stream_filtered(make_video):
+    """Verify drop-audio records the fallback reason when language filtering drops everything."""
+    # Given: audio_only.json (single english audio stream) with langs_to_keep=["fr"] and
+    # drop_original_audio=True so nothing matches and the safety fallback keeps it anyway
+    settings.update({"langs_to_keep": ["fr"], "drop_original_audio": True})
+    video = make_video("audio_only.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the drop-audio action is truthfully unapplied with the fallback reason
+    drop = next(a for a in plan.actions if a.label == "Drop unwanted audio")
+    assert drop.applied is False
+    assert drop.reason == "kept all audio to avoid a silent file"
 
 
 def test_downmix_records_applied_when_planned(make_video):

--- a/tests/test_clean_planning.py
+++ b/tests/test_clean_planning.py
@@ -100,7 +100,23 @@ def test_build_plan_h265_sets_video_codec_and_bitrates(make_video, tmp_path):
     video_stream = plan.streams[0]
     assert video_stream.codec == "libx265"
     assert video_stream.extra_args[0] == "-b:v:{n}"
-    assert "✔ Convert to H.265" in plan.substeps
+    h265_action = next(a for a in plan.actions if a.label == "Convert to H.265")
+    assert h265_action.applied is True
+
+
+def test_h265_records_applied_action(make_video):
+    """Verify --h265 records an applied action when the encode runs."""
+    # Given: reference.json (h264 video) with --h265 and a 1 MB input file
+    settings.update({"h265": True})
+    video = make_video("reference.json")
+    video.temp_file.path.write_bytes(b"0" * 1_000_000)
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the recorded action is applied
+    h265_action = next(a for a in plan.actions if a.label == "Convert to H.265")
+    assert h265_action.applied is True
 
 
 def test_build_plan_h265_skips_when_already_h265(make_video):
@@ -113,9 +129,26 @@ def test_build_plan_h265_skips_when_already_h265(make_video):
     # When: building the plan
     plan = video._build_plan()  # noqa: SLF001
 
-    # Then: the video stream stays a copy and no H.265 substep is recorded
+    # Then: the video stream stays a copy and no applied H.265 action is recorded
     assert plan.streams[0].codec == "copy"
-    assert "✔ Convert to H.265" not in plan.substeps
+    assert not any(a.label == "Convert to H.265" and a.applied for a in plan.actions)
+
+
+def test_h265_records_skip_reason_when_already_h265(make_video):
+    """Verify --h265 without --force records a skip reason pointing to --force."""
+    # Given: reference.json rewritten so the video codec is hevc
+    settings.update({"h265": True})
+    video = make_video("reference.json")
+    video.probe_box.streams[0].codec_name = "hevc"
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the recorded action is skipped with a reason pointing to --force
+    h265_action = next(a for a in plan.actions if a.label == "Convert to H.265")
+    assert h265_action.applied is False
+    assert h265_action.reason is not None
+    assert "use --force" in h265_action.reason
 
 
 def test_build_plan_1080p_scales_and_forces_encode(make_video):
@@ -131,7 +164,24 @@ def test_build_plan_1080p_scales_and_forces_encode(make_video):
     video_stream = plan.streams[0]
     assert video_stream.stream_filter == "scale=width=1920:height=-2"
     assert video_stream.codec is None
-    assert "✔ Convert to 1080p" in plan.substeps
+    scale_action = next(a for a in plan.actions if a.label == "Convert to 1080p")
+    assert scale_action.applied is True
+
+
+def test_scale_records_skip_reason_when_already_1080p(make_video):
+    """Verify --1080p on an already-1080p source records a skip reason."""
+    # Given: reference.json (1080p H264 video) and --1080p
+    settings.update({"video_1080": True})
+    video = make_video("reference.json")
+
+    # When: building the plan
+    plan = video._build_plan()  # noqa: SLF001
+
+    # Then: the recorded action is skipped with a reason naming 1080p
+    scale_action = next(a for a in plan.actions if a.label == "Convert to 1080p")
+    assert scale_action.applied is False
+    assert scale_action.reason is not None
+    assert "1080" in scale_action.reason
 
 
 def test_build_plan_h265_encodes_every_video_stream(make_video):

--- a/tests/test_clean_planning.py
+++ b/tests/test_clean_planning.py
@@ -382,11 +382,11 @@ def test_clean_noop_skips_ffmpeg(make_video, mock_ffmpeg):
     video = make_video("unmapped_channels.json")
 
     # When: cleaning
-    substeps = video.clean()
+    result = video.clean()
 
-    # Then: ffmpeg never runs and the no-op substeps are returned
+    # Then: ffmpeg never runs and no action was applied
     mock_ffmpeg.assert_not_called()
-    assert any("No streams to process" in step for step in substeps)
+    assert all(not action.applied for action in result)
 
 
 def test_drop_audio_records_applied_when_streams_dropped(make_video):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,14 +10,6 @@ from vid_cleaner.utils import copy_to_output
 from vid_cleaner.vidcleaner import VidCleaner, config_subcommand
 
 
-@pytest.fixture
-def restore_verbosity():
-    """Restore settings.verbosity after the test to avoid leaking state onto the shared singleton."""
-    original_verbosity = settings.verbosity
-    yield
-    settings.update({"verbosity": original_verbosity})
-
-
 @pytest.mark.parametrize(
     ("subcommand"),
     [("inspect"), ("clip"), ("clean"), ("cache")],
@@ -43,7 +35,7 @@ def test_vidcleaner_cli_help(capsys, subcommand: str) -> None:
     [("-v", 1), ("-vv", 2)],
 )
 def test_config_subcommand_persists_verbosity(
-    capsys, restore_verbosity, verbosity_flag: str, expected_verbosity: int
+    capsys, verbosity_flag: str, expected_verbosity: int
 ) -> None:
     """Verify the CLI verbosity flag is persisted onto settings.verbosity."""
     # Given: CLI arguments requesting a verbosity level via the cache subcommand

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,14 @@ from vid_cleaner.utils import copy_to_output
 from vid_cleaner.vidcleaner import VidCleaner, config_subcommand
 
 
+@pytest.fixture
+def restore_verbosity():
+    """Restore settings.verbosity after the test to avoid leaking state onto the shared singleton."""
+    original_verbosity = settings.verbosity
+    yield
+    settings.update({"verbosity": original_verbosity})
+
+
 @pytest.mark.parametrize(
     ("subcommand"),
     [("inspect"), ("clip"), ("clean"), ("cache")],
@@ -35,7 +43,7 @@ def test_vidcleaner_cli_help(capsys, subcommand: str) -> None:
     [("-v", 1), ("-vv", 2)],
 )
 def test_config_subcommand_persists_verbosity(
-    capsys, verbosity_flag: str, expected_verbosity: int
+    capsys, restore_verbosity, verbosity_flag: str, expected_verbosity: int
 ) -> None:
     """Verify the CLI verbosity flag is persisted onto settings.verbosity."""
     # Given: CLI arguments requesting a verbosity level via the cache subcommand

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import cappa
 import pytest
 
+from vid_cleaner import settings
 from vid_cleaner.utils import copy_to_output
 from vid_cleaner.vidcleaner import VidCleaner, config_subcommand
 
@@ -27,6 +28,26 @@ def test_vidcleaner_cli_help(capsys, subcommand: str) -> None:
     assert "Usage: vidcleaner" in output
     assert "--help" in output
     assert " [-v]" in output
+
+
+@pytest.mark.parametrize(
+    ("verbosity_flag", "expected_verbosity"),
+    [("-v", 1), ("-vv", 2)],
+)
+def test_config_subcommand_persists_verbosity(
+    capsys, verbosity_flag: str, expected_verbosity: int
+) -> None:
+    """Verify the CLI verbosity flag is persisted onto settings.verbosity."""
+    # Given: CLI arguments requesting a verbosity level via the cache subcommand
+    args = ["cache", verbosity_flag]
+
+    # When: invoking the CLI with config_subcommand as a dependency
+    with pytest.raises(cappa.Exit):
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: the computed verbosity from the CLI flag is persisted onto settings
+    capsys.readouterr()
+    assert settings.verbosity == expected_verbosity
 
 
 def test_copy_to_output_backs_up_existing(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,6 @@
+from vid_cleaner.config import settings
+
+
+def test_verbosity_defaults_to_zero():
+    """Verify verbosity setting defaults to 0."""
+    assert int(settings.get("verbosity", 0) or 0) == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,18 @@
 # type: ignore
 """Test the vidcleaner settings configuration."""
 
-from vid_cleaner.config import settings
+from vid_cleaner.config import SettingsManager
 
 
 def test_verbosity_defaults_to_zero():
-    """Verify verbosity setting defaults to 0."""
-    assert settings.verbosity == 0
+    """Verify the verbosity validator supplies a default of 0."""
+    # Given the settings singleton is re-initialized from scratch
+    original = SettingsManager._instance  # noqa: SLF001
+    try:
+        SettingsManager._instance = None  # noqa: SLF001
+        fresh = SettingsManager.initialize()
+
+        # Then the validator-supplied default is 0
+        assert fresh.verbosity == 0
+    finally:
+        SettingsManager._instance = original  # noqa: SLF001

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,9 @@
+# type: ignore
+"""Test the vidcleaner settings configuration."""
+
 from vid_cleaner.config import settings
 
 
 def test_verbosity_defaults_to_zero():
     """Verify verbosity setting defaults to 0."""
-    assert int(settings.get("verbosity", 0) or 0) == 0
+    assert settings.verbosity == 0

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,51 @@
+"""Tests for console output helpers."""
+
+from nclutils import pp
+
+from vid_cleaner.models.conversion_plan import PlanAction
+from vid_cleaner.utils import render_operations
+
+
+def _plain(capsys) -> str:
+    return capsys.readouterr().out
+
+
+def test_normal_mode_shows_only_applied(capsys):
+    """Verify normal mode renders only applied operations."""
+    pp.configure(verbosity=0)
+    actions = [
+        PlanAction(label="Reorder streams", applied=True),
+        PlanAction(
+            label="Convert to H.265", applied=False, reason="already H.265/VP9; use --force"
+        ),
+    ]
+    render_operations(actions, debug=False)
+    out = _plain(capsys)
+    assert "✔ Reorder streams" in out
+    assert "Convert to H.265" not in out
+
+
+def test_debug_mode_shows_skipped_with_reason(capsys):
+    """Verify debug mode renders all operations including skipped ones with reasons."""
+    pp.configure(verbosity=1)
+    actions = [
+        PlanAction(label="Reorder streams", applied=True),
+        PlanAction(
+            label="Convert to H.265", applied=False, reason="already H.265/VP9; use --force"
+        ),
+    ]
+    render_operations(actions, debug=True)
+    out = _plain(capsys)
+    assert "✔ Reorder streams" in out
+    assert "✖ Convert to H.265" in out
+    assert "already H.265/VP9; use --force" in out
+
+
+def test_no_applied_actions_shows_no_changes(capsys):
+    """Verify no applied actions in normal mode renders 'No changes needed' message."""
+    pp.configure(verbosity=0)
+    actions = [
+        PlanAction(label="Reorder streams", applied=False, reason="streams already in order")
+    ]
+    render_operations(actions, debug=False)
+    assert "No changes needed" in _plain(capsys)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,8 +1,7 @@
 """Tests for console output helpers."""
 
-from nclutils import pp
-
-from vid_cleaner.models.conversion_plan import PlanAction
+from vid_cleaner.constants import TREE_BRANCH, TREE_LAST
+from vid_cleaner.models import PlanAction
 from vid_cleaner.utils import render_operations
 
 
@@ -12,7 +11,6 @@ def _plain(capsys) -> str:
 
 def test_normal_mode_shows_only_applied(capsys):
     """Verify normal mode renders only applied operations."""
-    pp.configure(verbosity=0)
     actions = [
         PlanAction(label="Reorder streams", applied=True),
         PlanAction(
@@ -27,7 +25,6 @@ def test_normal_mode_shows_only_applied(capsys):
 
 def test_debug_mode_shows_skipped_with_reason(capsys):
     """Verify debug mode renders all operations including skipped ones with reasons."""
-    pp.configure(verbosity=1)
     actions = [
         PlanAction(label="Reorder streams", applied=True),
         PlanAction(
@@ -41,9 +38,22 @@ def test_debug_mode_shows_skipped_with_reason(capsys):
     assert "already H.265/VP9; use --force" in out
 
 
+def test_debug_mode_shows_tree_connectors(capsys):
+    """Verify each rendered line is prefixed with a tree connector, last line using TREE_LAST."""
+    actions = [
+        PlanAction(label="Reorder streams", applied=True),
+        PlanAction(
+            label="Convert to H.265", applied=False, reason="already H.265/VP9; use --force"
+        ),
+    ]
+    render_operations(actions, debug=True)
+    lines = _plain(capsys).splitlines()
+    assert TREE_BRANCH in lines[0]
+    assert TREE_LAST in lines[-1]
+
+
 def test_no_applied_actions_shows_no_changes(capsys):
     """Verify no applied actions in normal mode renders 'No changes needed' message."""
-    pp.configure(verbosity=0)
     actions = [
         PlanAction(label="Reorder streams", applied=False, reason="streams already in order")
     ]

--- a/tests/test_conversion_plan.py
+++ b/tests/test_conversion_plan.py
@@ -2,8 +2,7 @@
 """Test the ConversionPlan model."""
 
 from vid_cleaner.constants import CodecTypes
-from vid_cleaner.models import ConversionPlan, OutputStream
-from vid_cleaner.models.conversion_plan import PlanAction
+from vid_cleaner.models import ConversionPlan, OutputStream, PlanAction
 
 
 def test_build_command_maps_streams_in_order():

--- a/tests/test_conversion_plan.py
+++ b/tests/test_conversion_plan.py
@@ -3,6 +3,7 @@
 
 from vid_cleaner.constants import CodecTypes
 from vid_cleaner.models import ConversionPlan, OutputStream
+from vid_cleaner.models.conversion_plan import PlanAction
 
 
 def test_build_command_maps_streams_in_order():
@@ -175,3 +176,21 @@ def test_is_noop_false_when_any_stream_encodes():
     assert encoded.is_noop(stream_count=1) is False
     assert filtered.is_noop(stream_count=1) is False
     assert rewrapped.is_noop(stream_count=1) is False
+
+
+def test_plan_action_defaults():
+    """Verify PlanAction defaults reason to None."""
+    action = PlanAction(label="Downmix to stereo", applied=True)
+    assert action.label == "Downmix to stereo"
+    assert action.applied is True
+    assert action.reason is None
+
+
+def test_conversion_plan_actions_default_empty():
+    """Verify ConversionPlan actions default to empty list and can be mutated."""
+    plan = ConversionPlan()
+    assert plan.actions == []
+    plan.actions.append(
+        PlanAction(label="Reorder streams", applied=False, reason="streams already in order")
+    )
+    assert plan.actions[0].reason == "streams already in order"


### PR DESCRIPTION
## Summary

The `clean` command now prints the operations it actually performs for each file, listed up front before the progress bar, instead of a title derived from the requested flags. In verbose mode it also lists requested operations that were skipped, each with a reason.

## Changes

- Record each cleaning operation (reorder streams, drop unwanted audio, downmix to stereo, drop unwanted subtitles, convert to H.265/VP9, scale to 1080p) as a structured action on the conversion plan, capturing whether it ran and, when skipped, why.
- Render the action list beneath the file name before ffmpeg runs; the live progress label is now `Processing…`.
- Normal output shows only operations that ran (`✔ <operation>`); `-v`/`-vv` additionally shows skipped requested operations (`✖ <operation>  (<reason>)`), while unrequested conversions never appear.
- Report skips truthfully for the keep-all-audio fallback and for subtitles dropped by the VP9/WebM container.
- Add a `verbosity` setting that mirrors the `-v`/`-vv` flags, and reset it between tests to prevent cross-test leakage.
- Remove the previous settings-derived progress title and the per-plan `substeps` strings, sharing one tree renderer between the operation list and the write-output messages.
