### PR TITLE
fix(search): skip files that cannot be read as video

### DIFF
--- a/src/vid_cleaner/cli/search.py
+++ b/src/vid_cleaner/cli/search.py
@@ -9,6 +9,7 @@ from rich.table import Table
 
 from vid_cleaner.config import settings
 from vid_cleaner.constants import VideoContainerTypes
+from vid_cleaner.exceptions import VideoProbeError
 from vid_cleaner.utils import coerce_video_files
 from vid_cleaner.vidcleaner import SearchCommand
 
@@ -64,12 +65,19 @@ def main(search_cmd: SearchCommand) -> None:
     table.add_column("Video info")
 
     i = 0
+    unreadable: list[VideoProbeError] = []
     for video_file in track(
         video_files,
         description=f"Filtering {len(video_files)} files for {human_readable_filters}...",
         transient=True,
     ):
-        video_traits = video_file.get_traits()
+        # A video extension is no guarantee of video content; corrupt files and stubs like
+        # AppleDouble `._` sidecars must not abort the whole search.
+        try:
+            video_traits = video_file.get_traits()
+        except VideoProbeError as e:
+            unreadable.append(e)
+            continue
 
         matches = [trait for trait in video_traits if trait in settings.filters]
         if settings.filters and not matches:
@@ -78,8 +86,18 @@ def main(search_cmd: SearchCommand) -> None:
         i += 1
         table.add_row(str(i), video_file.name, ", ".join(matches), ", ".join(video_traits))
 
+    if unreadable:
+        pp.warning(f"Skipped {len(unreadable)} file(s) that could not be read as video")
+        pp.debug(
+            "Unreadable files", details=[f"{e.path}: {e.reason}" for e in unreadable], markup=False
+        )
+
     if i == 0:
-        pp.error(f"No video files found matching {human_readable_filters}")
+        pp.error(
+            f"No video files found matching {human_readable_filters}"
+            if human_readable_filters
+            else "No video files could be read"
+        )
         raise cappa.Exit(code=1)
 
     pp.console().print(table)

--- a/src/vid_cleaner/exceptions.py
+++ b/src/vid_cleaner/exceptions.py
@@ -1,0 +1,44 @@
+"""Exceptions raised by vid-cleaner."""
+
+from pathlib import Path
+
+__all__ = ["VideoProbeError"]
+
+
+class VideoProbeError(Exception):
+    """Raised when a file cannot be read as a video.
+
+    Carries the offending path so callers can decide whether one bad file aborts the run or is skipped and reported at the end.
+    """
+
+    def __init__(self, path: Path, reason: str) -> None:
+        """Initialize VideoProbeError.
+
+        Args:
+            path (Path): The file that could not be read.
+            reason (str): Short explanation of why the file could not be read.
+        """
+        self.path = path
+        self.reason = reason
+        super().__init__(f"Could not read '{path}' as a video file: {reason}")
+
+    @classmethod
+    def from_ffprobe_stderr(cls, path: Path, stderr: bytes | str | None) -> "VideoProbeError":
+        """Build an error from raw ffprobe stderr.
+
+        ffprobe prints its banner and library versions before the actual diagnostic, so only the final line is worth surfacing to the user.
+
+        Args:
+            path (Path): The path that failed to probe.
+            stderr (bytes | str | None): Everything ffprobe wrote to stderr.
+
+        Returns:
+            VideoProbeError: An error carrying ffprobe's own explanation.
+        """
+        text = stderr.decode("utf-8", errors="replace") if isinstance(stderr, bytes) else stderr
+
+        for line in reversed((text or "").splitlines()):
+            if stripped := line.strip():
+                return cls(path=path, reason=stripped.removeprefix(f"{path}: "))
+
+        return cls(path=path, reason="unknown ffprobe error")

--- a/src/vid_cleaner/utils/ffmpeg_utils.py
+++ b/src/vid_cleaner/utils/ffmpeg_utils.py
@@ -2,12 +2,11 @@
 
 from pathlib import Path
 
-import cappa
 import ffmpeg as python_ffmpeg
 from box import Box
-from nclutils import pp
 
 from vid_cleaner.constants import AudioLayout, CodecTypes
+from vid_cleaner.exceptions import VideoProbeError
 
 
 def channels_to_layout(channels: int) -> AudioLayout | None:
@@ -53,15 +52,12 @@ def run_ffprobe(path: Path) -> dict:  # pragma: no cover
         dict: A dictionary containing information about the video file.
 
     Raises:
-        cappa.Exit: If an error occurs while probing the video file.
+        VideoProbeError: If the file is corrupt or is not actually a video despite its extension.
     """
     try:
-        probe = python_ffmpeg.probe(path)
+        return python_ffmpeg.probe(path)
     except python_ffmpeg.Error as e:
-        pp.error(e.stderr)
-        raise cappa.Exit(code=1) from e
-
-    return probe
+        raise VideoProbeError.from_ffprobe_stderr(path=path, stderr=e.stderr) from e
 
 
 def get_probe_as_box(input_path: Path) -> Box:
@@ -74,6 +70,9 @@ def get_probe_as_box(input_path: Path) -> Box:
 
     Returns:
         Box: Box object containing normalized probe data with fields for format metadata and stream properties
+
+    Raises:
+        VideoProbeError: If the file cannot be probed or its streams cannot be normalized.
     """
     probe_box = Box(
         run_ffprobe(input_path),
@@ -91,14 +90,22 @@ def get_probe_as_box(input_path: Path) -> Box:
     probe_box.bit_rate = probe_box.format.bit_rate or None
 
     # Set stream codecs to enum
-    for stream in probe_box.streams:
-        stream.codec_type = CodecTypes(stream.codec_type.lower())
-        stream.bps = stream.tags.BPS or None
-        stream.title = stream.tags.title or None
-        # Preserve the raw count before it is bucketed into an enum; the downmix logic needs
-        # it to detect >7.1 (Atmos) layouts, which have no AudioLayout member.
-        stream.channel_count = stream.channels if isinstance(stream.channels, int) else None
-        stream.channels = channels_to_layout(stream.channels)
-        stream.language = stream.language or stream.tags.language or None
+    try:
+        for stream in probe_box.streams:
+            stream.codec_type = CodecTypes(str(stream.codec_type).lower())
+            # ffprobe omits `codec_name` for streams it cannot identify; the rest of the codebase
+            # calls `.lower()` on it unconditionally.
+            stream.codec_name = stream.codec_name if isinstance(stream.codec_name, str) else ""
+            stream.bps = stream.tags.BPS or None
+            stream.title = stream.tags.title or None
+            # Preserve the raw count before it is bucketed into an enum; the downmix logic needs
+            # it to detect >7.1 (Atmos) layouts, which have no AudioLayout member.
+            stream.channel_count = stream.channels if isinstance(stream.channels, int) else None
+            stream.channels = channels_to_layout(stream.channels)
+            stream.language = stream.language or stream.tags.language or None
+    except (AttributeError, TypeError, ValueError) as e:
+        # ffprobe can succeed on a non-video file and still report streams this model cannot
+        # describe; treat that as unreadable rather than crashing the caller.
+        raise VideoProbeError(path=input_path, reason=str(e)) from e
 
     return probe_box

--- a/src/vid_cleaner/vidcleaner.py
+++ b/src/vid_cleaner/vidcleaner.py
@@ -387,6 +387,8 @@ This command allows you to search for video files under a directory and display 
 
 By using filters, you can search for video files that match specific criteria. For example, you can search for video files that are in the H264 codec and have a resolution of 1080p.
 
+Files that can not be read as video, such as corrupt files or non-video files carrying a video extension, are counted and skipped rather than ending the search. Run with `-v` to list them.
+
 **Usage Examples:**
 ```shell
 # Search for video files that are in the H264 codec and have a resolution of 1080p up to 2 levels deep:

--- a/src/vid_cleaner/vidcleaner.py
+++ b/src/vid_cleaner/vidcleaner.py
@@ -12,6 +12,7 @@ from rich.traceback import install
 from vid_cleaner import settings
 from vid_cleaner.config import SettingsManager
 from vid_cleaner.constants import USER_CONFIG_PATH, PrintLevel, VideoTrait
+from vid_cleaner.exceptions import VideoProbeError
 from vid_cleaner.utils import create_default_config, parse_trait_filters
 
 
@@ -428,6 +429,11 @@ def main() -> None:  # pragma: no cover
         )
     except KeyboardInterrupt as e:
         pp.info("\nExiting...")
+        raise cappa.Exit(code=1) from e
+    except VideoProbeError as e:
+        # Commands given explicit files abort on an unreadable one; `search` handles its own
+        # skipping before the error can reach here.
+        pp.error(str(e))
         raise cappa.Exit(code=1) from e
 
 

--- a/tests/test_ffmpeg_utils.py
+++ b/tests/test_ffmpeg_utils.py
@@ -1,0 +1,50 @@
+"""Test ffprobe output normalization."""
+
+from pathlib import Path
+
+import pytest
+
+from vid_cleaner.constants import CodecTypes
+from vid_cleaner.exceptions import VideoProbeError
+from vid_cleaner.utils import get_probe_as_box
+
+
+@pytest.mark.parametrize(
+    "stream",
+    [
+        pytest.param({"index": 0, "codec_name": "bin_data"}, id="missing_codec_type"),
+        pytest.param({"index": 0, "codec_type": "nonsense"}, id="unknown_codec_type"),
+        pytest.param({"index": 0, "codec_type": 12}, id="non_string_codec_type"),
+    ],
+)
+def test_get_probe_as_box_rejects_undescribable_streams(mocker, stream: dict) -> None:
+    """Verify a stream this model cannot describe raises VideoProbeError rather than crashing."""
+    # Given: ffprobe succeeds but reports a stream with no usable codec type
+    mocker.patch(
+        "vid_cleaner.utils.ffmpeg_utils.run_ffprobe",
+        return_value={"format": {"filename": "x.mkv"}, "streams": [stream]},
+    )
+
+    # When: Normalizing the probe output
+    # Then: The file is reported as unreadable
+    with pytest.raises(VideoProbeError):
+        get_probe_as_box(Path("x.mkv"))
+
+
+def test_get_probe_as_box_defaults_missing_codec_name(mocker) -> None:
+    """Verify a stream without a codec name normalizes to an empty string."""
+    # Given: ffprobe reports a video stream whose codec it could not identify
+    mocker.patch(
+        "vid_cleaner.utils.ffmpeg_utils.run_ffprobe",
+        return_value={
+            "format": {"filename": "x.mkv"},
+            "streams": [{"index": 0, "codec_type": "video"}],
+        },
+    )
+
+    # When: Normalizing the probe output
+    probe_box = get_probe_as_box(Path("x.mkv"))
+
+    # Then: Downstream `.lower()` calls have a string to work with
+    assert probe_box.streams[0].codec_type == CodecTypes.VIDEO
+    assert probe_box.streams[0].codec_name == ""

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -7,6 +7,7 @@ import cappa
 import pytest
 
 from vid_cleaner import settings
+from vid_cleaner.exceptions import VideoProbeError
 from vid_cleaner.vidcleaner import VidCleaner, config_subcommand
 
 
@@ -109,3 +110,48 @@ def test_search_with_no_results(
     assert "Found 1 video files in 1/1 directories" in output
     assert "No video files found matching 'reorder'" in error
     assert "Matching filters" not in output
+
+
+@pytest.mark.parametrize(
+    ("verbosity", "lists_skipped_files"),
+    [(None, False), ("-v", True)],
+)
+def test_search_skips_unreadable_files(
+    capsys,
+    mocker,
+    mock_video_path,
+    debug,
+    mock_ffprobe_box,
+    mock_ffprobe,
+    verbosity,
+    lists_skipped_files,
+):
+    """Verify search reports and skips files it cannot probe while still listing readable ones."""
+    # Given: A directory holding one readable video and one file that ffprobe rejects
+    unreadable = mock_video_path.parent / "not_really_a_video.mkv"
+    unreadable.touch()
+    good_box = mock_ffprobe_box("reference.json")
+
+    def probe(path):
+        if path.name == unreadable.name:
+            raise VideoProbeError(path=path, reason="Invalid data found when processing input")
+        return good_box
+
+    mocker.patch("vid_cleaner.models.video_file.get_probe_as_box", side_effect=probe)
+
+    args = ["search", str(mock_video_path.parent), "--filters", "h264"]
+    if verbosity:
+        args.insert(0, verbosity)
+
+    # When: Running the search command
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output, error = capsys.readouterr()
+    debug(output + error, "output")
+
+    # Then: The readable file is still reported and the unreadable one is only counted
+    assert exc_info.value.code == 0
+    assert "1 │ test_video.mp4 │ h264" in output
+    assert "Skipped 1 file(s) that could not be read as video" in error
+    assert ("Unreadable files" in output + error) is lists_skipped_files


### PR DESCRIPTION
Makes `vidcleaner search` skip files it cannot read as video instead of
aborting the whole scan. A corrupt file, or a non-video file carrying a
video extension such as a macOS AppleDouble `._` sidecar, previously
ended the run partway through and discarded every result collected so
far.

## Changes

- `search` counts unreadable files and reports `Skipped N file(s) that
  could not be read as video`, listing the offending paths and ffprobe's
  reason only under `-v`/`-vv`.
- Probe failures raise a new `VideoProbeError` carrying the path and
  ffprobe's own one-line explanation, replacing the `cappa.Exit` that
  `run_ffprobe` raised from inside a lazy property.
- `clean`, `clip`, and `inspect` still abort on an unreadable file, now
  with that one-line message instead of the multi-kilobyte ffprobe
  banner printed as a byte string.
- Streams that ffprobe reports without a usable codec type are treated
  as unreadable, and a missing codec name normalizes to `""`. ffprobe
  omits both for content it cannot identify, and the surrounding code
  calls `.lower()` on them unconditionally.
- `search` reports `No video files could be read` when nothing was
  readable and no filters were supplied, instead of the truncated
  `No video files found matching `.
- `search --help` documents the skipping behavior.

## Behavior changes for existing users

- `search` over a directory containing an unreadable file now exits 0
  and prints its results; it previously exited 1 with no table. A run
  where nothing at all could be read still exits 1.

## Testing

- Verified against a directory holding a real h264 mkv beside an
  AppleDouble `._` stub: the readable file is listed and the run exits
  0. An all-unreadable directory exits 1.
- Confirmed `inspect` on the same stub exits 1 with the one-line reason.
- New regression tests cover the skip path, the debug-only listing, and
  normalization of missing, unknown, and non-string codec types.
- Full suite green: 149 passed. `ruff check`, `ruff format --check`, and
  `mypy` clean.
