### PR TITLE
feat(search): sort results and show file size and bitrate

### DIFF
--- a/src/vid_cleaner/cli/search.py
+++ b/src/vid_cleaner/cli/search.py
@@ -1,17 +1,48 @@
 """Search subcommand."""
 
+from collections.abc import Callable
+from typing import Any
+
 import cappa
 from nclutils import pp
 from nclutils.fs import find_files, find_subdirectories
 from rich.live import Live
 from rich.progress import track
-from rich.table import Table
 
 from vid_cleaner.config import settings
-from vid_cleaner.constants import VideoContainerTypes
+from vid_cleaner.constants import SortOrder, VideoContainerTypes
 from vid_cleaner.exceptions import VideoProbeError
+from vid_cleaner.models import SearchResult
 from vid_cleaner.utils import coerce_video_files
 from vid_cleaner.vidcleaner import SearchCommand
+from vid_cleaner.views import search_table
+
+# Each key pairs a getter with the direction that reads naturally for it: names ascend,
+# magnitudes descend. `--reverse` flips whichever is active.
+SortKey = Callable[[SearchResult], Any]
+SORT_KEYS: dict[SortOrder, tuple[SortKey, bool]] = {
+    SortOrder.ALPHA: (lambda result: str(result.video_file.path).lower(), False),
+    SortOrder.SIZE: (lambda result: result.size, True),
+    SortOrder.BITRATE: (lambda result: result.bitrate, True),
+}
+
+
+def coerce_bitrate(raw: str | int | None) -> int:
+    """Convert an ffprobe bit_rate value to an integer, falling back to zero.
+
+    ffprobe reports bit_rate as a string and omits it entirely for some containers, so
+    sorting needs a total order that a missing value cannot break.
+
+    Args:
+        raw (str | int | None): The `bit_rate` value from a probe box.
+
+    Returns:
+        int: The bitrate in bits per second, or 0 when it is missing or unparsable.
+    """
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
 
 
 def main(search_cmd: SearchCommand) -> None:
@@ -58,13 +89,7 @@ def main(search_cmd: SearchCommand) -> None:
         pp.warning(f"No video files found in {search_cmd.directory}")
         raise cappa.Exit(code=0)
 
-    table = Table(title="Video Files")
-    table.add_column("#")
-    table.add_column("Name")
-    table.add_column("Matching filters")
-    table.add_column("Video info")
-
-    i = 0
+    results: list[SearchResult] = []
     unreadable: list[VideoProbeError] = []
     for video_file in track(
         video_files,
@@ -83,23 +108,63 @@ def main(search_cmd: SearchCommand) -> None:
         if settings.filters and not matches:
             continue
 
-        i += 1
-        table.add_row(str(i), video_file.name, ", ".join(matches), ", ".join(video_traits))
+        # A file that vanishes between the probe above and this stat() (e.g. deleted by
+        # another process mid-scan) must not abort a batch search that may have already
+        # spent minutes probing the rest of the library.
+        try:
+            size = video_file.path.stat().st_size
+        except OSError as e:
+            unreadable.append(VideoProbeError(path=video_file.path, reason=str(e)))
+            continue
+
+        results.append(
+            SearchResult(
+                video_file=video_file,
+                traits=video_traits,
+                matches=matches,
+                size=size,
+                bitrate=coerce_bitrate(video_file.probe_box.bit_rate),
+            )
+        )
 
     if unreadable:
-        pp.warning(f"Skipped {len(unreadable)} file(s) that could not be read as video")
         pp.debug(
             "Unreadable files", details=[f"{e.path}: {e.reason}" for e in unreadable], markup=False
         )
 
-    if i == 0:
-        pp.error(
+    if not results:
+        # The table caption is the sole reporter of the skipped count on the success
+        # path, but it never renders here, so fold the count into the error instead of
+        # leaving the user unable to tell "nothing matches" from "nothing was readable".
+        message = (
             f"No video files found matching {human_readable_filters}"
             if human_readable_filters
             else "No video files could be read"
         )
+        if unreadable:
+            message += f" ({len(unreadable)} file(s) skipped as unreadable)"
+        pp.error(message)
         raise cappa.Exit(code=1)
 
-    pp.console().print(table)
+    # Presort by path so ties on the active key (e.g. every bitrate-less file) resolve
+    # deterministically instead of reflecting find_files' arbitrary scan order. `sort`
+    # is stable, so this ordering survives as the tiebreaker after the real sort below.
+    results.sort(key=SORT_KEYS[SortOrder.ALPHA][0])
+
+    key_fn, descends_by_default = SORT_KEYS[search_cmd.sort]
+    descending = descends_by_default != search_cmd.reverse
+    results.sort(key=key_fn, reverse=descending)
+
+    pp.console().print(
+        search_table(
+            results,
+            sort=search_cmd.sort,
+            descending=descending,
+            total=len(video_files),
+            skipped=len(unreadable),
+            filtered=bool(settings.filters),
+            root=search_cmd.directory.expanduser().resolve() if search_cmd.depth > 0 else None,
+        )
+    )
 
     raise cappa.Exit(code=0)

--- a/src/vid_cleaner/constants.py
+++ b/src/vid_cleaner/constants.py
@@ -84,6 +84,14 @@ class VideoTrait(StrEnum):
         return ", ".join(values)
 
 
+class SortOrder(StrEnum):
+    """Ordering applied to `search` results."""
+
+    ALPHA = "alpha"
+    SIZE = "size"
+    BITRATE = "bitrate"
+
+
 @dataclass
 class Resolution:
     """Resolution for vid-cleaner."""

--- a/src/vid_cleaner/models/__init__.py
+++ b/src/vid_cleaner/models/__init__.py
@@ -1,6 +1,7 @@
 """Models for vid-cleaner app."""
 
 from .conversion_plan import ConversionPlan, OutputStream, PlanAction
+from .search_result import SearchResult
 from .video_file import VideoFile
 
-__all__ = ["ConversionPlan", "OutputStream", "PlanAction", "VideoFile"]
+__all__ = ["ConversionPlan", "OutputStream", "PlanAction", "SearchResult", "VideoFile"]

--- a/src/vid_cleaner/models/search_result.py
+++ b/src/vid_cleaner/models/search_result.py
@@ -1,0 +1,25 @@
+"""Search result model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vid_cleaner.constants import VideoTrait
+    from vid_cleaner.models.video_file import VideoFile
+
+
+@dataclass
+class SearchResult:
+    """A probed video file that survived the active trait filters.
+
+    Carry everything the results table needs so rendering never has to re-probe a file
+    or touch the filesystem again.
+    """
+
+    video_file: VideoFile
+    traits: list[VideoTrait]
+    matches: list[VideoTrait]
+    size: int
+    bitrate: int

--- a/src/vid_cleaner/utils/cli.py
+++ b/src/vid_cleaner/utils/cli.py
@@ -4,6 +4,7 @@ import shutil
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import cappa
 from nclutils import pp
@@ -17,10 +18,12 @@ from vid_cleaner.constants import (
     VideoContainerTypes,
     VideoTrait,
 )
-from vid_cleaner.models.video_file import VideoFile
+
+if TYPE_CHECKING:
+    from vid_cleaner.models.video_file import VideoFile
 
 
-def coerce_video_files(files: list[Path]) -> list[VideoFile]:
+def coerce_video_files(files: list[Path]) -> list["VideoFile"]:
     """Parse and validate a list of video file paths.
 
     Verify each path exists and has a valid video container extension. Convert valid paths into VideoFile objects.
@@ -34,6 +37,10 @@ def coerce_video_files(files: list[Path]) -> list[VideoFile]:
     Raises:
         cappa.Exit: If a file doesn't exist or has an invalid extension
     """
+    # Imported here because `vid_cleaner.models.video_file` imports this package at module
+    # scope; a top-level import makes `vid_cleaner.models` unimportable on its own.
+    from vid_cleaner.models.video_file import VideoFile  # noqa: PLC0415
+
     for file in files:
         f = file.expanduser().resolve().absolute()
 

--- a/src/vid_cleaner/vidcleaner.py
+++ b/src/vid_cleaner/vidcleaner.py
@@ -11,7 +11,7 @@ from rich.traceback import install
 
 from vid_cleaner import settings
 from vid_cleaner.config import SettingsManager
-from vid_cleaner.constants import USER_CONFIG_PATH, PrintLevel, VideoTrait
+from vid_cleaner.constants import USER_CONFIG_PATH, PrintLevel, SortOrder, VideoTrait
 from vid_cleaner.exceptions import VideoProbeError
 from vid_cleaner.utils import create_default_config, parse_trait_filters
 
@@ -389,10 +389,16 @@ By using filters, you can search for video files that match specific criteria. F
 
 Files that can not be read as video, such as corrupt files or non-video files carrying a video extension, are counted and skipped rather than ending the search. Run with `-v` to list them.
 
+Results are sorted alphabetically by path. Use `--sort=size` or `--sort=bitrate` to order by
+file size or overall bitrate instead, largest first. `--reverse` flips whichever order is active.
+
 **Usage Examples:**
 ```shell
 # Search for video files that are in the H264 codec and have a resolution of 1080p up to 2 levels deep:
 vidcleaner search --filters=h264,1080p --depth=2
+
+# List 4k files, largest first:
+vidcleaner search --filters=4k --sort=size
 ```
 """,
     invoke="vid_cleaner.cli.search.main",
@@ -419,6 +425,24 @@ class SearchCommand:
             show_default=False,
         ),
     ] = None
+    sort: Annotated[
+        SortOrder,
+        cappa.Arg(
+            help="Sort results by name, file size, or bitrate.",
+            long=True,
+            short=False,
+            show_default=True,
+        ),
+    ] = SortOrder.ALPHA
+    reverse: Annotated[
+        bool,
+        cappa.Arg(
+            help="Reverse the sort order",
+            long=True,
+            short=False,
+            show_default=True,
+        ),
+    ] = False
 
 
 def main() -> None:  # pragma: no cover

--- a/src/vid_cleaner/views/__init__.py
+++ b/src/vid_cleaner/views/__init__.py
@@ -1,5 +1,5 @@
 """Views for the VidCleaner application."""
 
-from .tables import stream_table
+from .tables import search_table, stream_table
 
-__all__ = ["stream_table"]
+__all__ = ["search_table", "stream_table"]

--- a/src/vid_cleaner/views/tables.py
+++ b/src/vid_cleaner/views/tables.py
@@ -1,7 +1,248 @@
 """Tables for the VidCleaner application."""
 
-from box import Box
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich import box
+from rich.filesize import decimal
 from rich.table import Table
+from rich.text import Text
+
+from vid_cleaner.constants import SortOrder
+
+if TYPE_CHECKING:
+    from box import Box
+
+    from vid_cleaner.constants import VideoTrait
+    from vid_cleaner.models import SearchResult
+
+# Scene releases lead with the title and switch to release metadata at the year (movies) or
+# the season/episode token (TV). Everything after that point restates, in scene shorthand,
+# what the traits line already says in normalized form.
+TITLE_END_RE = re.compile(r"\b((?:19|20)\d{2}|S\d{2}E\d{2})\b", re.IGNORECASE)
+
+
+def format_size(size: int) -> Text:
+    """Render a byte count with the magnitude prominent and the unit dim.
+
+    Args:
+        size (int): File size in bytes.
+
+    Returns:
+        Text: Styled size, e.g. `51.8 GB`.
+    """
+    magnitude, _, unit = decimal(size).rpartition(" ")
+    text = Text(magnitude)
+    text.append(f" {unit}", style="dim")
+    return text
+
+
+def format_bitrate(bitrate: int) -> Text:
+    """Render a bitrate in megabits per second, or a dash when it is unknown.
+
+    Args:
+        bitrate (int): Bitrate in bits per second; 0 means ffprobe did not report one.
+
+    Returns:
+        Text: Styled bitrate, e.g. `24.3 Mb/s`, or a dim `--`.
+    """
+    if not bitrate:
+        return Text("--", style="dim")
+
+    text = Text(f"{bitrate / 1_000_000:.1f}")
+    text.append(" Mb/s", style="dim")
+    return text
+
+
+def format_name(filename: str, *, parent: str = "") -> Text:
+    """Render a filename with the title emphasized over its release metadata.
+
+    Keep the suffix visible because the traits line says nothing about the container, and
+    keep dots inside the metadata tail because tokens like `DTS-HD.MA.7.1` depend on them.
+
+    Args:
+        filename (str): The file name, including its suffix.
+        parent (str): A directory path to render as a dim segment ahead of the filename,
+            e.g. so a recursive search's results stay grouped by directory. Omitted
+            entirely when empty.
+
+    Returns:
+        Text: Styled name with a bold title and a dim metadata tail.
+    """
+    stem, _, suffix = filename.rpartition(".")
+    if not stem:  # No suffix to split off.
+        stem, suffix = filename, ""
+
+    # AppleDouble sidecar files (`._name`) and genuinely hidden dotfiles (`.private`,
+    # `..hidden`) carry leading dots that are not a scene-release separator. Split them
+    # off and keep them verbatim (never space-replaced or stripped) so a hidden file's
+    # rendered name round-trips exactly to the name on disk.
+    leading_dots = stem[: len(stem) - len(stem.lstrip("."))]
+    stem = stem[len(leading_dots) :]
+
+    # Only the LAST year/SxxEyy token can end the title: a movie year is often followed
+    # by a resolution that also starts with two digits, and a first-match search would
+    # wrongly stop at that leading number instead of the real title/metadata boundary.
+    matches = list(TITLE_END_RE.finditer(stem))
+    match = matches[-1] if matches else None
+
+    # Build by appending rather than via `Text(..., style=...)`: the constructor sets a base
+    # style on the whole object instead of a span, which erases the title/tail distinction
+    # once the cell is composed with others.
+    text = Text()
+    if parent:
+        text.append(f"{parent}/", style="dim")
+
+    # A dot immediately after the match is a real scene-release separator to bridge with a
+    # space. Any other boundary (a parenthesis, a space, or nothing) was never a separator,
+    # so the whole stem renders as the title instead of manufacturing a tail from it.
+    if match and stem[match.end() : match.end() + 1] == ".":
+        text.append(leading_dots + stem[: match.end()].replace(".", " "), style="bold")
+        # The dot right after the match was the only thing to bridge; if nothing
+        # follows it, there is no tail left to append and no separator to emit.
+        tail = stem[match.end() + 1 :]
+        if tail:
+            text.append(" " + tail, style="dim")
+    else:
+        text.append(leading_dots + stem.replace(".", " "), style="bold")
+
+    if suffix:
+        text.append(f".{suffix}", style="dim")
+
+    return text
+
+
+def format_traits(traits: list[VideoTrait], matches: list[VideoTrait]) -> Text:
+    """Render a trait list with the filter matches lifted out of the dim background.
+
+    Args:
+        traits (list[VideoTrait]): Every trait detected on the file, in display order.
+        matches (list[VideoTrait]): The subset that matched the active filters.
+
+    Returns:
+        Text: Styled trait line separated by middots.
+    """
+    matched = set(matches)
+    text = Text()
+    for index, trait in enumerate(traits):
+        if index:
+            text.append(" · ", style="dim")
+        text.append(trait.value, style="" if trait in matched else "dim")
+
+    return text
+
+
+def sort_header(label: str, *, active: bool, descending: bool) -> Text:
+    """Render a column header, marking the active sort key with a direction arrow.
+
+    The arrow reports the direction values actually run in, not which flag produced it:
+    `↓` for high-to-low (or Z-to-A), `↑` for the reverse.
+
+    Args:
+        label (str): The column name.
+        active (bool): Whether this column is the active sort key.
+        descending (bool): Whether values run from largest to smallest down the column.
+
+    Returns:
+        Text: Styled header text.
+    """
+    if not active:
+        return Text(label, style="dim")
+
+    return Text(f"{label} {'↓' if descending else '↑'}", style="bold cyan")
+
+
+def search_table(  # noqa: PLR0913
+    results: list[SearchResult],
+    *,
+    sort: SortOrder,
+    descending: bool,
+    total: int,
+    skipped: int,
+    filtered: bool,
+    root: Path | None = None,
+) -> Table:
+    """Build the `search` results table.
+
+    Stack each file's traits beneath its name inside one cell so the filename gets the
+    table's full width instead of competing with a traits column, and so filter matches
+    can be shown as emphasis rather than as a second column repeating the same tokens.
+
+    Args:
+        results (list[SearchResult]): Matching files, already in display order.
+        sort (SortOrder): The active sort key, marked in the column headers.
+        descending (bool): Whether the rows run from largest to smallest on the active
+            key, so the header arrow can point the way the values actually run.
+        total (int): How many candidate video files were discovered.
+        skipped (int): How many files could not be read as video.
+        filtered (bool): Whether any trait filters were active.
+        root (Path | None): The directory a recursive search started from. When set,
+            each row's directory renders as a dim segment ahead of its filename so
+            same-named files in different directories stay distinguishable. Omitted
+            for a non-recursive (depth 0) search.
+
+    Returns:
+        Table: Rich table ready to print.
+    """
+    summary = f"{len(results)} of {total} files matched" if filtered else f"{len(results)} files"
+    caption = f"{summary} · {skipped} skipped" if skipped else summary
+
+    table = Table(
+        box=box.SIMPLE_HEAD,
+        pad_edge=False,
+        show_edge=False,
+        caption=caption,
+        caption_style="dim",
+        caption_justify="left",
+        # Rich's default header_style ("table.header" = bold) would otherwise combine
+        # with each inactive header's own "dim" style, rendering bold+dim instead of
+        # plain dim.
+        header_style="",
+    )
+    table.add_column("#", justify="right", style="dim", header_style="dim", no_wrap=True)
+    # Fold rather than truncate: a clipped filename cannot identify a file.
+    table.add_column(
+        sort_header("File", active=sort == SortOrder.ALPHA, descending=descending), overflow="fold"
+    )
+    table.add_column(
+        sort_header("Size", active=sort == SortOrder.SIZE, descending=descending),
+        justify="right",
+        no_wrap=True,
+    )
+    table.add_column(
+        sort_header("Bitrate", active=sort == SortOrder.BITRATE, descending=descending),
+        justify="right",
+        no_wrap=True,
+    )
+
+    for index, result in enumerate(results, start=1):
+        parent = ""
+        if root is not None:
+            try:
+                relative_dir = result.video_file.path.parent.relative_to(root)
+            except ValueError:
+                # A result outside the search root (should not happen in practice)
+                # falls back to the bare filename rather than raising.
+                relative_dir = Path()
+            if relative_dir != Path():
+                parent = relative_dir.as_posix()
+
+        # Take the filename from the same resolved path the directory segment came from,
+        # so a symlinked file never renders its link name under its target's directory.
+        name_cell = format_name(result.video_file.path.name, parent=parent)
+        name_cell.append("\n")
+        name_cell.append(format_traits(result.traits, result.matches))
+        table.add_row(
+            str(index),
+            name_cell,
+            format_size(result.size),
+            format_bitrate(result.bitrate),
+        )
+
+    return table
 
 
 def stream_table(ffprobe_box: Box) -> Table:
@@ -15,7 +256,10 @@ def stream_table(ffprobe_box: Box) -> Table:
     Returns:
         Table: Rich table containing formatted stream information
     """
-    table = Table(title=ffprobe_box.name)
+    # Read the size from disk rather than ffprobe's `format.size`, which is a string and is
+    # absent for some containers, so both views always report the same number.
+    size = format_size(ffprobe_box.path_to_file.stat().st_size).plain
+    table = Table(title=f"{ffprobe_box.name} ({size})")
     table.add_column("#")
     table.add_column("Type")
     table.add_column("Codec Name")

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -34,6 +34,32 @@ def test_inspect_table(tmp_path, capsys, debug, mock_video_path, mock_ffprobe_bo
     assert re.search(r"1920 +│ 1080 +│ Test", output)
 
 
+def test_inspect_title_shows_file_size(capsys, mock_video_path, mocker, mock_ffprobe_box):
+    """Verify the stream table title reports the file's size."""
+    # Given: A video file with a known size on disk
+    mock_video_path.write_bytes(b"\0" * 2000)
+    # mock_ffprobe_box sets path_to_file to the fixture JSON it reads, not the video
+    # under test; point it at mock_video_path so the size read from disk is the 2000
+    # bytes just written, matching what get_probe_as_box does for a real probe.
+    probe_box = mock_ffprobe_box("reference.json")
+    probe_box.path_to_file = mock_video_path
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=probe_box,
+    )
+
+    # When: Inspecting the file
+    args = ["inspect", str(mock_video_path)]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The title carries the human readable size
+    assert exc_info.value.code == 0
+    assert "(2.0 kB)" in output
+
+
 def test_inspect_json(tmp_path, capsys, debug, mock_video_path, mock_ffprobe, mocker):
     """Verify inspect command displays video information in JSON format."""
     # Given: Mock video file and ffprobe data

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -233,26 +233,17 @@ def test_search_skips_files_that_vanish_before_stat(
     # e.g. deleted mid-scan by another process
     vanished = mock_video_path.parent / "vanished.mkv"
     vanished.touch()
-    vanished_resolved = vanished.resolve()
     good_box = mock_ffprobe_box("reference.json")
-    mocker.patch("vid_cleaner.models.video_file.get_probe_as_box", return_value=good_box)
 
-    # find_files' own is_file() check stats every candidate during discovery, before the
-    # search loop reaches this file at all; only the later call (reading its size for the
-    # results table) should observe the file as gone.
-    original_stat = Path.stat
-    stat_calls = 0
+    # Discovery finishes before any file is probed, so deleting the file here leaves it
+    # present for the scan that found it and genuinely gone by the time its size is read.
+    # `missing_ok` because each probed file is re-probed on every stream-property access.
+    def probe(path: Path) -> object:
+        if path.name == vanished.name:
+            vanished.unlink(missing_ok=True)
+        return good_box
 
-    def flaky_stat(self, *args: object, **kwargs: object) -> object:
-        nonlocal stat_calls
-        if self == vanished_resolved:
-            stat_calls += 1
-            if stat_calls > 2:
-                message = "No such file or directory"
-                raise OSError(message)
-        return original_stat(self, *args, **kwargs)
-
-    mocker.patch.object(Path, "stat", flaky_stat)
+    mocker.patch("vid_cleaner.models.video_file.get_probe_as_box", side_effect=probe)
 
     # When: Running the search command
     args = ["search", str(mock_video_path.parent), "--filters", "h264"]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,7 @@
 # type: ignore
 """Test the search command."""
 
+import copy
 from pathlib import Path
 
 import cappa
@@ -28,6 +29,42 @@ def set_default_settings(tmp_path, mocker, mock_ffprobe_box):
             "drop_original_audio": False,
         }
     )
+
+
+@pytest.fixture
+def search_dir(tmp_path, mocker, mock_ffprobe_box):
+    """Build a directory of video files with per-file size and bitrate.
+
+    Names may include a nested path, e.g. "aaa/mike.mkv", to exercise recursive
+    searches; the parent directory is created automatically.
+
+    Returns:
+        Callable[[list[tuple[str, int, int]]], Path]: Call with `(filename, size_bytes,
+            bitrate_bps)` triples to create the files and patch ffprobe to report the
+            matching bitrate for each one.
+    """
+
+    def _inner(files: list[tuple[str, int, int]]) -> Path:
+        reference = mock_ffprobe_box("reference.json")
+        directory = tmp_path / "library"
+        directory.mkdir(exist_ok=True)
+
+        boxes = {}
+        for name, size, bitrate in files:
+            path = directory / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"\0" * size)
+            file_box = copy.deepcopy(reference)
+            file_box.bit_rate = str(bitrate) if bitrate else None
+            boxes[name] = file_box
+
+        mocker.patch(
+            "vid_cleaner.models.video_file.get_probe_as_box",
+            side_effect=lambda path: boxes[path.relative_to(directory).as_posix()],
+        )
+        return directory
+
+    return _inner
 
 
 def test_search_no_video_files(tmp_path, capsys, mocker, debug):
@@ -77,7 +114,8 @@ def test_search_with_results(
 
     assert exc_info.value.code == 0
     assert "Found 1 video files in 1/1 directories" in output
-    assert "1 │ test_video.mp4 │ h264" in output
+    assert "test_video.mp4" in output
+    assert "h264" in output
 
 
 def test_search_with_no_results(
@@ -109,7 +147,36 @@ def test_search_with_no_results(
     assert exc_info.value.code == 1
     assert "Found 1 video files in 1/1 directories" in output
     assert "No video files found matching 'reorder'" in error
-    assert "Matching filters" not in output
+    assert "Bitrate" not in output
+
+
+def test_search_no_results_reports_skipped_count(capsys, mock_video_path, mocker, mock_ffprobe_box):
+    """Verify the no-results error still surfaces how many files were skipped as unreadable."""
+    # Given: One file that fails to probe and one that probes but matches no active filter
+    unreadable = mock_video_path.parent / "not_really_a_video.mkv"
+    unreadable.touch()
+    good_box = mock_ffprobe_box("reference.json")
+
+    def probe(path):
+        if path.name == unreadable.name:
+            raise VideoProbeError(path=path, reason="Invalid data found when processing input")
+        return good_box
+
+    mocker.patch("vid_cleaner.models.video_file.get_probe_as_box", side_effect=probe)
+
+    # When: Filtering for a trait no readable file has, so results is empty and the
+    # success-path table caption (the usual home for the skipped count) never renders
+    args = ["search", str(mock_video_path.parent), "--filters", "reorder"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    _, error = capsys.readouterr()
+
+    # Then: The error reports both the mismatch and the skipped file
+    assert exc_info.value.code == 1
+    assert "No video files found matching 'reorder'" in error
+    assert "1" in error
+    assert "skipped" in error
 
 
 @pytest.mark.parametrize(
@@ -152,6 +219,299 @@ def test_search_skips_unreadable_files(
 
     # Then: The readable file is still reported and the unreadable one is only counted
     assert exc_info.value.code == 0
-    assert "1 │ test_video.mp4 │ h264" in output
-    assert "Skipped 1 file(s) that could not be read as video" in error
+    assert "test_video.mp4" in output
+    assert "h264" in output
+    assert "1 skipped" in output
     assert ("Unreadable files" in output + error) is lists_skipped_files
+
+
+def test_search_skips_files_that_vanish_before_stat(
+    capsys, mocker, mock_video_path, mock_ffprobe_box
+):
+    """Verify a file that disappears between probing and stat() is skipped, not fatal."""
+    # Given: A second file that probes fine but vanishes before its size can be read,
+    # e.g. deleted mid-scan by another process
+    vanished = mock_video_path.parent / "vanished.mkv"
+    vanished.touch()
+    vanished_resolved = vanished.resolve()
+    good_box = mock_ffprobe_box("reference.json")
+    mocker.patch("vid_cleaner.models.video_file.get_probe_as_box", return_value=good_box)
+
+    # find_files' own is_file() check stats every candidate during discovery, before the
+    # search loop reaches this file at all; only the later call (reading its size for the
+    # results table) should observe the file as gone.
+    original_stat = Path.stat
+    stat_calls = 0
+
+    def flaky_stat(self, *args: object, **kwargs: object) -> object:
+        nonlocal stat_calls
+        if self == vanished_resolved:
+            stat_calls += 1
+            if stat_calls > 2:
+                message = "No such file or directory"
+                raise OSError(message)
+        return original_stat(self, *args, **kwargs)
+
+    mocker.patch.object(Path, "stat", flaky_stat)
+
+    # When: Running the search command
+    args = ["search", str(mock_video_path.parent), "--filters", "h264"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The scan completes, reporting the readable file and counting the vanished
+    # one as skipped rather than aborting the whole search
+    assert exc_info.value.code == 0
+    assert "test_video.mp4" in output
+    assert "1 skipped" in output
+
+
+@pytest.mark.parametrize(
+    ("sort_args", "expected_order"),
+    [
+        ([], ["apple", "banana", "cherry"]),
+        (["--sort", "alpha"], ["apple", "banana", "cherry"]),
+        (["--sort", "alpha", "--reverse"], ["cherry", "banana", "apple"]),
+        (["--sort", "size"], ["banana", "cherry", "apple"]),
+        (["--sort", "size", "--reverse"], ["apple", "cherry", "banana"]),
+        (["--sort", "bitrate"], ["cherry", "apple", "banana"]),
+        (["--sort", "bitrate", "--reverse"], ["banana", "apple", "cherry"]),
+    ],
+)
+def test_search_sort_orders_results(capsys, search_dir, sort_args, expected_order):
+    """Verify each sort key and --reverse order the results as documented."""
+    # Given: Three files whose alphabetical, size, and bitrate orders all differ
+    directory = search_dir(
+        [
+            ("apple.mkv", 100, 2_000_000),
+            ("banana.mkv", 300, 1_000_000),
+            ("cherry.mkv", 200, 3_000_000),
+        ]
+    )
+
+    # When: Running the search command with the given sort arguments
+    args = ["search", str(directory), "--filters", "h264", *sort_args]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The rows appear in the expected order
+    assert exc_info.value.code == 0
+    positions = [output.index(name) for name in expected_order]
+    assert positions == sorted(positions)
+
+
+def test_search_sort_alpha_uses_full_path(capsys, search_dir):
+    """Verify alphabetical sorting groups results by directory, not by bare filename."""
+    # Given: Files whose directory order and filename order disagree
+    directory = search_dir([("zulu.mkv", 100, 1_000_000), ("aaa/mike.mkv", 100, 1_000_000)])
+
+    # When: Running a recursive search with the default sort
+    args = ["search", str(directory), "--depth", "1", "--filters", "h264"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The nested `aaa/mike.mkv` sorts before the top-level `zulu.mkv`
+    assert exc_info.value.code == 0
+    assert output.index("mike") < output.index("zulu")
+
+
+def test_search_table_shows_relative_directory_when_recursive(capsys, search_dir):
+    """Verify a recursive search renders each result's directory as a dim path segment."""
+    # Given: A file nested one directory below the search root
+    directory = search_dir([("zulu.mkv", 100, 1_000_000), ("aaa/mike.mkv", 100, 1_000_000)])
+
+    # When: Running a recursive search
+    args = ["search", str(directory), "--depth", "1", "--filters", "h264"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The nested result's row shows its directory ahead of the filename
+    assert exc_info.value.code == 0
+    assert "aaa/mike.mkv" in output
+
+
+def test_search_table_omits_directory_when_not_recursive(capsys, search_dir):
+    """Verify a depth-0 search renders the bare filename with no directory prefix."""
+    # Given: A file at the top level of the search directory
+    directory = search_dir([("mike.mkv", 100, 1_000_000)])
+
+    # When: Running a non-recursive search (the default depth)
+    args = ["search", str(directory), "--filters", "h264"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: Only the bare filename appears, with no directory segment
+    assert exc_info.value.code == 0
+    assert "mike.mkv" in output
+    assert str(directory) not in output
+
+
+def test_search_sort_bitrate_handles_missing_bitrate(capsys, search_dir):
+    """Verify a file whose probe omits bit_rate sorts last instead of raising."""
+    # Given: One file with a bitrate and one without
+    directory = search_dir([("apple.mkv", 100, 0), ("banana.mkv", 100, 5_000_000)])
+
+    # When: Sorting by bitrate
+    args = ["search", str(directory), "--filters", "h264", "--sort", "bitrate"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The file with a bitrate sorts ahead of the one without
+    assert exc_info.value.code == 0
+    assert output.index("banana") < output.index("apple")
+
+
+def test_search_sort_ties_are_deterministic(capsys, search_dir, mocker):
+    """Verify equal-size files render in a stable order regardless of scan order."""
+    # Given: Three files with an identical size, so `--sort=size` cannot break the tie
+    directory = search_dir([("alpha.mkv", 100, 0), ("bravo.mkv", 100, 0), ("charlie.mkv", 100, 0)])
+    # find_files' scan order is arbitrary; scramble it here to prove the table's row
+    # order does not simply mirror whatever order the filesystem happened to return.
+    scrambled = [directory / "bravo.mkv", directory / "charlie.mkv", directory / "alpha.mkv"]
+    mocker.patch("vid_cleaner.cli.search.find_files", return_value=scrambled)
+
+    # When: Sorting by size
+    args = ["search", str(directory), "--filters", "h264", "--sort", "size"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: Ties fall back to alphabetical-by-path order, not scan order
+    assert exc_info.value.code == 0
+    assert output.index("alpha") < output.index("bravo") < output.index("charlie")
+
+
+def test_search_rejects_unknown_sort_key(capsys):
+    """Verify an unsupported --sort value is refused by the CLI."""
+    # Given: An invalid sort key
+    args = ["search", ".", "--sort", "duration"]
+
+    # When: Running the search command
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command exits with an error
+    assert exc_info.value.code != 0
+
+
+def test_search_table_shows_size_and_bitrate(capsys, search_dir):
+    """Verify the results table reports each file's size and bitrate."""
+    # Given: A single file with a known size and bitrate
+    directory = search_dir([("apple.mkv", 1500, 2_000_000)])
+
+    # When: Running the search command
+    args = ["search", str(directory), "--filters", "h264"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: Both columns and both values are present
+    assert exc_info.value.code == 0
+    assert "Size" in output
+    assert "Bitrate" in output
+    assert "1.5 kB" in output
+    assert "2.0 Mb/s" in output
+
+
+def test_search_table_marks_the_active_sort_column(capsys, search_dir):
+    """Verify the sorted column header carries a direction arrow that --reverse flips."""
+    # Given: A directory with one matching file
+    directory = search_dir([("apple.mkv", 100, 2_000_000)])
+
+    # When: Sorting by size
+    args = ["search", str(directory), "--filters", "h264", "--sort", "size"]
+    with pytest.raises(cappa.Exit):
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+    forward = capsys.readouterr().out
+
+    # When: Sorting by size in reverse
+    with pytest.raises(cappa.Exit):
+        cappa.invoke(obj=VidCleaner, argv=[*args, "--reverse"], deps=[config_subcommand])
+    reversed_output = capsys.readouterr().out
+
+    # Then: The arrow marks the size column and flips with --reverse
+    assert "Size ↓" in forward
+    assert "Size ↑" in reversed_output
+
+
+def test_search_table_arrow_reports_the_direction_rows_run(capsys, search_dir):
+    """Verify the arrow follows the rendered order, not the --reverse flag."""
+    # Given: Two files whose alphabetical order is visible in the table
+    directory = search_dir([("apple.mkv", 100, 2_000_000), ("banana.mkv", 100, 1_000_000)])
+
+    # When: Sorting alphabetically, which ascends by default
+    args = ["search", str(directory), "--filters", "h264"]
+    with pytest.raises(cappa.Exit):
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+    forward = capsys.readouterr().out
+
+    # When: Reversing that order
+    with pytest.raises(cappa.Exit):
+        cappa.invoke(obj=VidCleaner, argv=[*args, "--reverse"], deps=[config_subcommand])
+    reversed_output = capsys.readouterr().out
+
+    # Then: A→Z rows carry the up arrow and Z→A rows the down arrow, matching the
+    # meaning the size and bitrate columns give the same symbols
+    assert "File ↑" in forward
+    assert forward.index("apple") < forward.index("banana")
+    assert "File ↓" in reversed_output
+    assert reversed_output.index("banana") < reversed_output.index("apple")
+
+
+def test_search_table_caption_reports_counts(capsys, search_dir):
+    """Verify the caption reports how many files matched out of those scanned."""
+    # Given: Two files where only one matches the active filter
+    directory = search_dir([("apple.mkv", 100, 2_000_000), ("banana.mkv", 100, 1_000_000)])
+
+    # When: Running a search whose filter matches both
+    args = ["search", str(directory), "--filters", "h264"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The caption states the matched and scanned counts
+    assert exc_info.value.code == 0
+    assert "2 of 2 files matched" in output
+
+
+def test_search_table_caption_reports_skipped_files(
+    capsys, mock_video_path, mocker, mock_ffprobe_box
+):
+    """Verify the caption counts files that could not be read as video."""
+    # Given: One readable video and one file ffprobe rejects
+    unreadable = mock_video_path.parent / "not_really_a_video.mkv"
+    unreadable.touch()
+    good_box = mock_ffprobe_box("reference.json")
+
+    def probe(path):
+        if path.name == unreadable.name:
+            raise VideoProbeError(path=path, reason="Invalid data found when processing input")
+        return good_box
+
+    mocker.patch("vid_cleaner.models.video_file.get_probe_as_box", side_effect=probe)
+
+    # When: Running the search command
+    args = ["search", str(mock_video_path.parent), "--filters", "h264"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The caption reports the skipped file
+    assert exc_info.value.code == 0
+    assert "1 skipped" in output

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,0 +1,213 @@
+# type: ignore
+"""Test the table render helpers."""
+
+import pytest
+from rich.console import Console
+from rich.table import Table
+
+from vid_cleaner.constants import VideoTrait
+from vid_cleaner.views.tables import (
+    format_bitrate,
+    format_name,
+    format_size,
+    format_traits,
+    sort_header,
+)
+
+
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [(0, "0 bytes"), (84_000_000, "84.0 MB"), (51_800_000_000, "51.8 GB")],
+)
+def test_format_size_renders_human_readable(size, expected):
+    """Verify byte counts render as human readable magnitudes."""
+    # Given/When: Formatting a byte count
+    result = format_size(size)
+
+    # Then: The text reads as a human readable size
+    assert result.plain == expected
+
+
+@pytest.mark.parametrize(
+    ("bitrate", "expected"),
+    [(0, "--"), (1_200_000, "1.2 Mb/s"), (24_300_000, "24.3 Mb/s")],
+)
+def test_format_bitrate_renders_megabits(bitrate, expected):
+    """Verify bitrates render in megabits per second and missing values render as a dash."""
+    # Given/When: Formatting a bitrate
+    result = format_bitrate(bitrate)
+
+    # Then: The text reads in Mb/s, or as a dash when absent
+    assert result.plain == expected
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_plain", "expected_bold"),
+    [
+        (
+            "Arrival.2016.2160p.UHD.BluRay.HEVC.DTS-HD.MA.7.1-SWTYBLZ.mkv",
+            "Arrival 2016 2160p.UHD.BluRay.HEVC.DTS-HD.MA.7.1-SWTYBLZ.mkv",
+            "Arrival 2016",
+        ),
+        (
+            "The.Bear.S03E07.1080p.WEB-DL.DDP5.1.H.264-NTb.mkv",
+            "The Bear S03E07 1080p.WEB-DL.DDP5.1.H.264-NTb.mkv",
+            "The Bear S03E07",
+        ),
+        ("home video clip.mp4", "home video clip.mp4", "home video clip"),
+        # Plex/Jellyfin/Sonarr/Radarr rename conventions: no dot separates the title
+        # from the trailing year/episode punctuation, so nothing should be split off.
+        ("Arrival (2016).mkv", "Arrival (2016).mkv", "Arrival (2016)"),
+        (
+            "The Bear - S03E07 - Napkins.mkv",
+            "The Bear - S03E07 - Napkins.mkv",
+            "The Bear - S03E07 - Napkins",
+        ),
+        ("Movie.2016.mkv", "Movie 2016.mkv", "Movie 2016"),
+        ("Show.S03E07.mkv", "Show S03E07.mkv", "Show S03E07"),
+        (
+            "2001 A Space Odyssey (1968).mkv",
+            "2001 A Space Odyssey (1968).mkv",
+            "2001 A Space Odyssey (1968)",
+        ),
+        # Leading dots (AppleDouble sidecar files, and genuinely hidden dotfiles) are not
+        # a scene-release separator; they must round-trip to disk exactly, never stripped.
+        ("._Sidecar.mkv", "._Sidecar.mkv", "._Sidecar"),
+        (".private.mkv", ".private.mkv", ".private"),
+        ("..hidden.mkv", "..hidden.mkv", "..hidden"),
+        # A boundary dot that is itself the last character before the suffix leaves an
+        # empty tail; no bridging space should be manufactured from nothing.
+        ("Arrival.2016..mkv", "Arrival 2016.mkv", "Arrival 2016"),
+        ("Show.S03E07..mkv", "Show S03E07.mkv", "Show S03E07"),
+    ],
+)
+def test_format_name_splits_title_from_release_metadata(filename, expected_plain, expected_bold):
+    """Verify the title renders bold and the release metadata tail renders dim."""
+    # Given/When: Formatting a filename
+    result = format_name(filename)
+
+    # Then: The full name survives and only the title carries bold
+    assert result.plain == expected_plain
+    bold = "".join(
+        result.plain[span.start : span.end] for span in result.spans if "bold" in str(span.style)
+    )
+    assert bold == expected_bold
+
+
+def test_format_name_preserves_dots_in_metadata():
+    """Verify dots inside technical tokens survive so DTS-HD.MA.7.1 stays readable."""
+    # Given/When: Formatting a name whose tail holds dotted technical tokens
+    result = format_name("Blade.Runner.2049.2017.1080p.x264.DTS-HD.MA.5.1-FGT.mkv")
+
+    # Then: The dotted tokens are intact and the bold title runs through the LAST
+    # year token, not the first (2049 would otherwise wrongly end the title)
+    assert "DTS-HD.MA.5.1-FGT" in result.plain
+    bold = "".join(
+        result.plain[span.start : span.end] for span in result.spans if "bold" in str(span.style)
+    )
+    assert bold == "Blade Runner 2049 2017"
+
+
+def test_format_name_never_emits_a_trailing_separator_for_an_empty_tail():
+    """Verify a name with nothing after the matched token renders with no stray space."""
+    # Given/When: Formatting a name whose match consumes the entire stem
+    result = format_name("Show.S03E07.mkv")
+
+    # Then: No space is inserted between the title and the suffix
+    assert result.plain == "Show S03E07.mkv"
+    assert "  " not in result.plain
+
+
+def test_format_name_never_bridges_a_gap_that_was_not_a_dot():
+    """Verify a non-dot boundary after the match is left untouched, not bridged with a space."""
+    # Given/When: Formatting a name whose match is followed by a parenthesis, not a dot
+    result = format_name("Arrival (2016).mkv")
+
+    # Then: The on-disk spacing survives exactly
+    assert result.plain == "Arrival (2016).mkv"
+
+
+def test_format_name_prepends_a_dim_parent_segment():
+    """Verify a parent directory renders as a dim segment ahead of the filename."""
+    # Given/When: Formatting a filename with a parent directory
+    result = format_name("S01E01 Mole Hunt.mkv", parent="tv/archer")
+
+    # Then: The parent renders dim and the filename keeps its usual styling
+    assert result.plain == "tv/archer/S01E01 Mole Hunt.mkv"
+    dim = "".join(
+        result.plain[span.start : span.end] for span in result.spans if "dim" in str(span.style)
+    )
+    assert "tv/archer/" in dim
+    bold = "".join(
+        result.plain[span.start : span.end] for span in result.spans if "bold" in str(span.style)
+    )
+    assert bold == "S01E01 Mole Hunt"
+
+
+def test_format_name_omits_the_parent_segment_when_empty():
+    """Verify no parent separator appears when parent is the default empty string."""
+    # Given/When: Formatting a filename with no parent
+    result = format_name("S01E01 Mole Hunt.mkv")
+
+    # Then: The plain text carries no leading slash
+    assert result.plain == "S01E01 Mole Hunt.mkv"
+
+
+def test_format_traits_emphasizes_matches():
+    """Verify matched traits render undimmed while unmatched traits render dim."""
+    # Given: A trait list where only one entry matched the active filters
+    traits = [VideoTrait.FHD, VideoTrait.H264, VideoTrait.COMMENTARY]
+    matches = [VideoTrait.COMMENTARY]
+
+    # When: Formatting the traits
+    result = format_traits(traits, matches)
+
+    # Then: The separator and unmatched traits are dim, the match is not
+    assert result.plain == "1080p · h264 · commentary"
+    dim = "".join(
+        result.plain[span.start : span.end] for span in result.spans if "dim" in str(span.style)
+    )
+    assert "commentary" not in dim
+    assert "1080p" in dim
+    assert "h264" in dim
+
+
+def test_format_traits_rendered_output_distinguishes_matches():
+    """Verify a matched trait carries no dim escape while an unmatched one does, once rendered.
+
+    A `format_traits` unit test on spans alone cannot catch a base style applied via the
+    `Text` constructor instead of a span: that mistake is invisible until the cell is
+    actually composed into a table and rendered to ANSI, which is what this test does.
+    """
+    # Given: A trait list where only one entry matched the active filters, placed in a
+    # real table cell rather than inspected as a standalone Text object
+    traits = [VideoTrait.FHD, VideoTrait.H264, VideoTrait.COMMENTARY]
+    matches = [VideoTrait.COMMENTARY]
+    table = Table()
+    table.add_column("Traits")
+    table.add_row(format_traits(traits, matches))
+
+    # When: Rendering the composed table to ANSI-capable output
+    console = Console(force_terminal=True, width=80, color_system="standard")
+    with console.capture() as capture:
+        console.print(table)
+    rendered = capture.get()
+
+    # Then: The unmatched traits are wrapped in a dim escape, the matched one is not
+    assert "\x1b[2mh264\x1b[0m" in rendered
+    assert "\x1b[2m1080p\x1b[0m" in rendered
+    assert "\x1b[2mcommentary" not in rendered
+    assert "commentary" in rendered
+
+
+@pytest.mark.parametrize(
+    ("active", "descending", "expected"),
+    [(False, True, "Size"), (True, True, "Size ↓"), (True, False, "Size ↑")],
+)
+def test_sort_header_marks_the_active_column(active, descending, expected):
+    """Verify only the active sort column carries a direction arrow."""
+    # Given/When: Building a column header
+    result = sort_header("Size", active=active, descending=descending)
+
+    # Then: The arrow appears only when the column is the active sort key
+    assert result.plain == expected


### PR DESCRIPTION
Adds `--sort` and `--reverse` to `vidcleaner search`, ordering results by
name, file size, or overall bitrate instead of the arbitrary filesystem
order they came back in. The results table now reports each file's size and
bitrate. `inspect` shows the file size in its stream table title.

## Changes

- `--sort` takes `alpha` (default), `size`, or `bitrate`. Names ascend,
  magnitudes descend, and `--reverse` flips whichever order is active.
- `alpha` sorts on the full path, so a `--depth` search stays grouped by
  directory. Ties fall back to path order, so the same library renders in
  the same order on every run.
- The table gains `Size` and `Bitrate` columns. Bitrate is the signal size
  alone cannot give: a 5 GB feature film is unremarkable where a 5 GB
  episode is bloated.
- The active sort column's header carries an arrow pointing the direction
  its values actually run.
- The `Matching filters` column is gone. Matches are always a subset of the
  traits shown beside them, so the old table printed the same tokens twice.
  Matched traits now render at full weight against dim unmatched ones,
  which frees the width the numeric columns needed.
- Traits render beneath the filename inside one cell, giving the name the
  table's full width. Scene-release names show the title at full weight and
  the release metadata dim.
- A recursive search prefixes each row with its directory, so the
  path-based ordering is visible rather than looking arbitrary.
- `utils/cli.py` defers its `VideoFile` import, so `import
  vid_cleaner.models` no longer fails with a partially initialized module.

## Behavior changes for existing users

- Default result order is now alphabetical by path rather than the order
  the filesystem returned.
- The count of files skipped as unreadable moved from a standalone warning
  into the table caption. It still appears in the error message when
  nothing matched, and `-v` still lists the paths.
- A file that disappears between discovery and sizing is counted as skipped
  instead of aborting a scan that already spent minutes on ffprobe.

## Testing

Full suite green: 198 passed, 91.9% coverage.

The table's emphasis is ANSI styling that a passing test run does not
display, so the rendered output was also checked directly at 80 and 100
columns, covering both caption forms, a missing bitrate, and filenames in
scene, Plex, and dotfile naming styles.
