### PR TITLE
feat(clean): add --from to clean what a search query matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ dist/
 
 # docs
 docs/
+
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ vidcleaner search /media --filters=4k --sort=size --limit=5
 vidcleaner clean --from /media --filters=4k --sort=size --limit=5 --h265
 ```
 
-`clean` renders the same table `search` does, then asks for confirmation before transcoding anything. Pass `--yes` to skip the prompt in scripts and cron jobs, or `--dryrun` to preview without being asked. Running without a terminal and without `--yes` is an error rather than a hang.
+`clean` renders the same table `search` does, then asks for confirmation before transcoding anything. The prompt states whether each original will be backed up or overwritten in place. Pass `--yes` to skip the prompt in scripts and cron jobs, or `--dryrun` to preview without being asked. Running without a terminal and without `--yes` is an error rather than a hang.
 
-`--from` cannot be combined with explicit file paths or with `--out`.
+`--from` cannot be combined with explicit file paths or with `--out`, and must name an existing directory. `--yes` and the query flags (`--filters`, `--sort`, `--reverse`, `--depth`, `--limit`) are only meaningful with `--from` and are refused without it. `--limit` must be 1 or greater.
 
 When cleaning several files, a failure on one file does not stop the run. Every remaining file is still processed, failures are listed at the end, and the command exits with a non-zero status.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ vidcleaner clean --from /media --filters=4k --sort=size --limit=5 --h265
 
 `clean` and `clip` replace the file they were given. The original is not deleted: it is renamed alongside the result as a timestamped `.bak` copy. Pass `--overwrite` to skip the backup and rewrite the file in place with no way back, or `--out PATH` (single input file only) to write somewhere else and leave the input untouched.
 
+`--vp9` is the exception, because VP9 has to go in a WebM container. `vidcleaner clean --vp9 movie.mkv` writes `movie.webm` next to the input. Without `--overwrite` the original `movie.mkv` is left where it is; with `--overwrite` it is removed, so the container change does not leave two copies of the same film on disk.
+
 When cleaning several files, a failure on one file does not stop the run. Every remaining file is still processed, failures are listed at the end, and the command exits with a non-zero status.
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ python -m pip install --user vid-cleaner
 
 Run `vidcleaner --help` to see the available commands and options.
 
+### Searching for video files
+
+`vidcleaner search DIRECTORY` finds video files under a directory and prints a table of matches. Narrow the search with `--filters`, control how deep it recurses with `--depth`, and change the order with `--sort` and `--reverse`. Use `--limit` to keep only the top results on the active sort key:
+
+```shell
+# The five largest 4k files, two directories deep
+vidcleaner search /media --filters=4k --sort=size --depth=2 --limit=5
+```
+
+### Cleaning what you searched for
+
+`clean` accepts the same query flags as `search`, so a `search` command is a preview of the `clean` command that acts on it. Swap the positional directory for `--from`:
+
+```shell
+# Preview
+vidcleaner search /media --filters=4k --sort=size --limit=5
+
+# Act on exactly that selection
+vidcleaner clean --from /media --filters=4k --sort=size --limit=5 --h265
+```
+
+`clean` renders the same table `search` does, then asks for confirmation before transcoding anything. Pass `--yes` to skip the prompt in scripts and cron jobs, or `--dryrun` to preview without being asked. Running without a terminal and without `--yes` is an error rather than a hang.
+
+`--from` cannot be combined with explicit file paths or with `--out`.
+
+When cleaning several files, a failure on one file does not stop the run. Every remaining file is still processed, failures are listed at the end, and the command exits with a non-zero status.
+
 ### Configuration
 
 Defaults for vid-cleaner are set in the configuration file located at `~/.config/vid-cleaner/config.toml`. When vid-cleaner is run, it will create this file if it does not exist. All options can be overridden on the command line.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ vidcleaner clean --from /media --filters=4k --sort=size --limit=5 --h265
 
 `--from` cannot be combined with explicit file paths or with `--out`, and must name an existing directory. `--yes` and the query flags (`--filters`, `--sort`, `--reverse`, `--depth`, `--limit`) are only meaningful with `--from` and are refused without it. `--limit` must be 1 or greater.
 
+### Where the output goes
+
+`clean` and `clip` replace the file they were given. The original is not deleted: it is renamed alongside the result as a timestamped `.bak` copy. Pass `--overwrite` to skip the backup and rewrite the file in place with no way back, or `--out PATH` (single input file only) to write somewhere else and leave the input untouched.
+
 When cleaning several files, a failure on one file does not stop the run. Every remaining file is still processed, failures are listed at the end, and the command exits with a non-zero status.
 
 ### Configuration

--- a/src/vid_cleaner/cli/clean_video.py
+++ b/src/vid_cleaner/cli/clean_video.py
@@ -21,11 +21,12 @@ from vid_cleaner.vidcleaner import CleanCommand
 from vid_cleaner.models.video_file import VideoFile  # isort: skip
 
 
-def write_output(video_file: VideoFile) -> list[str]:
+def write_output(video_file: VideoFile, *, out_override: Path | None = None) -> list[str]:
     """Copy the processed result to the output path and return the closing substep messages.
 
     Args:
         video_file (VideoFile): The processed video file to write out.
+        out_override (Path | None): The user's explicit `--out` destination, when given.
 
     Returns:
         list[str]: Substep messages describing the backup and save, or a single note when nothing changed.
@@ -49,7 +50,11 @@ def write_output(video_file: VideoFile) -> list[str]:
     except OSError as e:
         messages.append(f"{SYMBOL_CROSS} Warning: could not clean up temporary files: {e}")
 
-    if settings.overwrite and out_file != video_file.path:
+    # This removal exists for a container change that renamed the result (e.g. `.mkv` to
+    # `.webm`), where `--overwrite` means "do not leave two copies of the same film".
+    # `--out` writes to a destination the user chose, so the input is not a leftover copy
+    # of the output and must survive.
+    if settings.overwrite and out_override is None and out_file != video_file.path:
         pp.debug(f"Delete: {video_file.path}")
         try:
             video_file.path.unlink()
@@ -168,7 +173,7 @@ def main(clean_cmd: CleanCommand) -> None:
         try:
             video_file.clean()
             if not settings.dryrun:
-                substeps.extend(write_output(video_file))
+                substeps.extend(write_output(video_file, out_override=out_path_override))
         # One unusable or failing file must not discard the files queued behind it.
         # `cappa.Exit` is deliberately not caught: it carries KeyboardInterrupt, which
         # means stop the whole run.

--- a/src/vid_cleaner/cli/clean_video.py
+++ b/src/vid_cleaner/cli/clean_video.py
@@ -67,7 +67,8 @@ def select_video_files(clean_cmd: CleanCommand) -> list[VideoFile]:
 
     Raises:
         cappa.Exit: If the two modes are mixed, if discovery flags appear without
-            `--from`, or if neither a file nor `--from` was given.
+            `--from`, if neither a file nor `--from` was given, or if `--from` does not
+            name an existing directory.
     """
     discovery = clean_cmd.discovery
     # Compare against defaults rather than asking cappa what the user typed; an explicit
@@ -78,6 +79,7 @@ def select_video_files(clean_cmd: CleanCommand) -> list[VideoFile]:
         or discovery.depth
         or discovery.reverse
         or discovery.sort != SortOrder.ALPHA
+        or clean_cmd.yes
     )
 
     if clean_cmd.from_ is not None and clean_cmd.files:
@@ -85,7 +87,9 @@ def select_video_files(clean_cmd: CleanCommand) -> list[VideoFile]:
         raise cappa.Exit(code=1)
 
     if clean_cmd.from_ is None and uses_discovery_flags:
-        pp.error("`--filters`, `--sort`, `--reverse`, `--depth`, and `--limit` require `--from`")
+        pp.error(
+            "These options require `--from`: `--filters`, `--sort`, `--reverse`, `--depth`, `--limit`, `--yes`"
+        )
         raise cappa.Exit(code=1)
 
     if clean_cmd.from_ is None:
@@ -93,6 +97,12 @@ def select_video_files(clean_cmd: CleanCommand) -> list[VideoFile]:
             pp.error("Provide file path(s) or `--from` to discover them")
             raise cappa.Exit(code=1)
         return coerce_video_files(clean_cmd.files)
+
+    # A missing or non-directory `--from` would otherwise discover nothing and exit 0, so a
+    # typo or an unmounted media share would report success having cleaned nothing.
+    if not clean_cmd.from_.is_dir():
+        pp.error(f"`--from` must be an existing directory: {clean_cmd.from_}")
+        raise cappa.Exit(code=1)
 
     filters = set(settings.filters)
     report = discover_video_files(

--- a/src/vid_cleaner/cli/clean_video.py
+++ b/src/vid_cleaner/cli/clean_video.py
@@ -112,22 +112,16 @@ def select_video_files(clean_cmd: CleanCommand) -> list[VideoFile]:
         pp.error(f"`--from` must be an existing directory: {clean_cmd.from_}")
         raise cappa.Exit(code=1)
 
-    filters = set(settings.filters)
     report = discover_video_files(
         clean_cmd.from_,
         depth=discovery.depth,
-        filters=filters,
+        filters=set(settings.filters),
         sort=discovery.sort,
         reverse=discovery.reverse,
         limit=discovery.limit,
     )
 
-    present_discovery(
-        report,
-        root=clean_cmd.from_,
-        filters=filters,
-        recursive=discovery.depth > 0,
-    )
+    present_discovery(report, root=clean_cmd.from_)
 
     # A dry run previews rather than acts, so there is nothing to approve.
     if not settings.dryrun:

--- a/src/vid_cleaner/cli/clean_video.py
+++ b/src/vid_cleaner/cli/clean_video.py
@@ -6,6 +6,9 @@ import cappa
 from nclutils import pp
 
 from vid_cleaner import settings
+from vid_cleaner.cli.discovery_output import confirm_selection, present_discovery
+from vid_cleaner.constants import SortOrder
+from vid_cleaner.controllers.discovery import discover_video_files
 from vid_cleaner.utils import (
     coerce_video_files,
     copy_to_output,
@@ -43,6 +46,73 @@ def write_output(video_file: VideoFile) -> list[str]:
     return messages
 
 
+def select_video_files(clean_cmd: CleanCommand) -> list[VideoFile]:
+    """Resolve the files to clean from either explicit paths or a `--from` discovery run.
+
+    Keep the two modes strictly separate so a query and a path list can never disagree
+    about what the command is about to rewrite.
+
+    Args:
+        clean_cmd (CleanCommand): The parsed clean command.
+
+    Returns:
+        list[VideoFile]: The files to process, in the order they should be processed.
+
+    Raises:
+        cappa.Exit: If the two modes are mixed, if discovery flags appear without
+            `--from`, or if neither a file nor `--from` was given.
+    """
+    discovery = clean_cmd.discovery
+    # Compare against defaults rather than asking cappa what the user typed; an explicit
+    # `--sort=alpha` would have been a no-op anyway, so treating it as unset is harmless.
+    uses_discovery_flags = bool(
+        discovery.filters
+        or discovery.limit is not None
+        or discovery.depth
+        or discovery.reverse
+        or discovery.sort != SortOrder.ALPHA
+    )
+
+    if clean_cmd.from_ is not None and clean_cmd.files:
+        pp.error("`--from` cannot be combined with explicit file paths")
+        raise cappa.Exit(code=1)
+
+    if clean_cmd.from_ is None and uses_discovery_flags:
+        pp.error("`--filters`, `--sort`, `--reverse`, `--depth`, and `--limit` require `--from`")
+        raise cappa.Exit(code=1)
+
+    if clean_cmd.from_ is None:
+        if not clean_cmd.files:
+            pp.error("Provide file path(s) or `--from` to discover them")
+            raise cappa.Exit(code=1)
+        return coerce_video_files(clean_cmd.files)
+
+    filters = set(settings.filters)
+    report = discover_video_files(
+        clean_cmd.from_,
+        depth=discovery.depth,
+        filters=filters,
+        sort=discovery.sort,
+        reverse=discovery.reverse,
+        limit=discovery.limit,
+    )
+
+    present_discovery(
+        report,
+        root=clean_cmd.from_,
+        filters=filters,
+        recursive=discovery.depth > 0,
+    )
+
+    # A dry run previews rather than acts, so there is nothing to approve.
+    if not settings.dryrun:
+        confirm_selection(report, assume_yes=clean_cmd.yes)
+
+    # Discovery already probed every file and `VideoFile` caches its probe, so reusing
+    # these instances skips a second ffprobe per file.
+    return [result.video_file for result in report.results]
+
+
 def main(clean_cmd: CleanCommand) -> None:
     """Process video files according to specified cleaning options.
 
@@ -59,9 +129,12 @@ def main(clean_cmd: CleanCommand) -> None:
         pp.error("Cannot convert to both H265 and VP9")
         raise cappa.Exit(code=1)
 
-    out_path_override = resolve_out_path_override(clean_cmd.files)
+    # Check the `--out`/`--from` conflict before discovery runs, so an empty `--from`
+    # directory can't short-circuit the command with "no files found" ahead of this error.
+    out_path_override = resolve_out_path_override(clean_cmd.files, from_directory=clean_cmd.from_)
+    video_files = select_video_files(clean_cmd)
 
-    for video_file in coerce_video_files(clean_cmd.files):
+    for video_file in video_files:
         settings.out_path = out_path_override or video_file.path
 
         # Print the video name first so live progress bars and clean()'s up-front operation

--- a/src/vid_cleaner/cli/clean_video.py
+++ b/src/vid_cleaner/cli/clean_video.py
@@ -38,11 +38,17 @@ def write_output(video_file: VideoFile) -> list[str]:
         Path(settings.out_path),
         overwrite=settings.overwrite,
     )
-    video_file.temp_file.clean_up()
 
-    if settings.overwrite and out_file != video_file.path:
-        pp.debug(f"Delete: {video_file.path}")
-        video_file.path.unlink()
+    # The write above already landed and swapped the result into place, so a failure past
+    # this point is temp-directory housekeeping, not a failed write: warn instead of
+    # discarding the "Saved to" message and counting a successful file as failed.
+    try:
+        video_file.temp_file.clean_up()
+        if settings.overwrite and out_file != video_file.path:
+            pp.debug(f"Delete: {video_file.path}")
+            video_file.path.unlink()
+    except OSError as e:
+        messages.append(f"{SYMBOL_CROSS} Warning: could not clean up temporary files: {e}")
 
     return messages
 
@@ -124,7 +130,8 @@ def main(clean_cmd: CleanCommand) -> None:
         clean_cmd (CleanCommand): Clean-specific command options
 
     Raises:
-        cappa.Exit: If incompatible options are specified (e.g., both H265 and VP9)
+        cappa.Exit: If incompatible options are specified (e.g., both H265 and VP9), or
+            if one or more files failed to process.
     """
     if settings.h265 and settings.vp9:
         pp.error("Cannot convert to both H265 and VP9")
@@ -154,8 +161,20 @@ def main(clean_cmd: CleanCommand) -> None:
         # `cappa.Exit` is deliberately not caught: it carries KeyboardInterrupt, which
         # means stop the whole run.
         except (VideoCleanError, VideoProbeError, RuntimeError, OSError) as e:
-            failures.append(f"{video_file.path.name}: {e}")
-            substeps.append(f"{SYMBOL_CROSS} Failed: {e}")
+            # VideoCleanError/VideoProbeError's str() already embeds the path, so use the
+            # short reason instead to avoid naming the file twice in one line.
+            detail = e.reason if isinstance(e, (VideoCleanError, VideoProbeError)) else str(e)
+            failures.append(f"{video_file.path.name}: {detail}")
+            substeps.append(f"{SYMBOL_CROSS} Failed: {detail}")
+            # A failed file still leaves its full-size temp transcode on disk; clear it now
+            # rather than letting a batch that fails on every file pile up N of them until
+            # atexit finally clears them.
+            try:
+                video_file.temp_file.clean_up()
+            except OSError as cleanup_error:
+                pp.debug(
+                    f"Could not clean up temporary files for {video_file.path}: {cleanup_error}"
+                )
         finally:
             render_substeps(substeps)
 

--- a/src/vid_cleaner/cli/clean_video.py
+++ b/src/vid_cleaner/cli/clean_video.py
@@ -40,15 +40,23 @@ def write_output(video_file: VideoFile) -> list[str]:
     )
 
     # The write above already landed and swapped the result into place, so a failure past
-    # this point is temp-directory housekeeping, not a failed write: warn instead of
-    # discarding the "Saved to" message and counting a successful file as failed.
+    # this point is housekeeping, not a failed write: warn instead of discarding the
+    # "Saved to" message and counting a successful file as failed. Each step is guarded
+    # separately so a failed temp cleanup cannot skip the removal below, and so neither
+    # failure is ever reported under the other one's description.
     try:
         video_file.temp_file.clean_up()
-        if settings.overwrite and out_file != video_file.path:
-            pp.debug(f"Delete: {video_file.path}")
-            video_file.path.unlink()
     except OSError as e:
         messages.append(f"{SYMBOL_CROSS} Warning: could not clean up temporary files: {e}")
+
+    if settings.overwrite and out_file != video_file.path:
+        pp.debug(f"Delete: {video_file.path}")
+        try:
+            video_file.path.unlink()
+        except OSError as e:
+            messages.append(
+                f"{SYMBOL_CROSS} Warning: could not remove the original {video_file.path}: {e}"
+            )
 
     return messages
 

--- a/src/vid_cleaner/cli/clean_video.py
+++ b/src/vid_cleaner/cli/clean_video.py
@@ -7,8 +7,9 @@ from nclutils import pp
 
 from vid_cleaner import settings
 from vid_cleaner.cli.discovery_output import confirm_selection, present_discovery
-from vid_cleaner.constants import SortOrder
+from vid_cleaner.constants import SYMBOL_CROSS, SortOrder
 from vid_cleaner.controllers.discovery import discover_video_files
+from vid_cleaner.exceptions import VideoCleanError, VideoProbeError
 from vid_cleaner.utils import (
     coerce_video_files,
     copy_to_output,
@@ -134,6 +135,8 @@ def main(clean_cmd: CleanCommand) -> None:
     out_path_override = resolve_out_path_override(clean_cmd.files, from_directory=clean_cmd.from_)
     video_files = select_video_files(clean_cmd)
 
+    failures: list[str] = []
+
     for video_file in video_files:
         settings.out_path = out_path_override or video_file.path
 
@@ -147,7 +150,17 @@ def main(clean_cmd: CleanCommand) -> None:
             video_file.clean()
             if not settings.dryrun:
                 substeps.extend(write_output(video_file))
+        # One unusable or failing file must not discard the files queued behind it.
+        # `cappa.Exit` is deliberately not caught: it carries KeyboardInterrupt, which
+        # means stop the whole run.
+        except (VideoCleanError, VideoProbeError, RuntimeError, OSError) as e:
+            failures.append(f"{video_file.path.name}: {e}")
+            substeps.append(f"{SYMBOL_CROSS} Failed: {e}")
         finally:
             render_substeps(substeps)
+
+    if failures:
+        pp.error(f"{len(failures)} file(s) failed", details=failures, markup=False)
+        raise cappa.Exit(code=1)
 
     raise cappa.Exit(code=0)

--- a/src/vid_cleaner/cli/clip_video.py
+++ b/src/vid_cleaner/cli/clip_video.py
@@ -7,6 +7,7 @@ import cappa
 from nclutils import pp
 
 from vid_cleaner import settings
+from vid_cleaner.constants import SYMBOL_CROSS
 from vid_cleaner.utils import (
     coerce_video_files,
     copy_to_output,
@@ -58,8 +59,15 @@ def main(clip_cmd: ClipCommand) -> None:
                     Path(settings.out_path),
                     overwrite=settings.overwrite,
                 )
-                video.temp_file.clean_up()
+                # The clip is already written, so keep its messages and treat a cleanup
+                # failure as a warning rather than losing the save and raising past main().
                 substeps.extend(messages)
+                try:
+                    video.temp_file.clean_up()
+                except OSError as e:
+                    substeps.append(
+                        f"{SYMBOL_CROSS} Warning: could not clean up temporary files: {e}"
+                    )
         finally:
             render_substeps(substeps)
 

--- a/src/vid_cleaner/cli/discovery_output.py
+++ b/src/vid_cleaner/cli/discovery_output.py
@@ -19,27 +19,21 @@ from vid_cleaner.views import search_table
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from vid_cleaner.constants import VideoTrait
     from vid_cleaner.controllers.discovery import DiscoveryReport
 
 
-def present_discovery(
-    report: DiscoveryReport,
-    *,
-    root: Path,
-    filters: set[VideoTrait],
-    recursive: bool,
-) -> None:
+def present_discovery(report: DiscoveryReport, *, root: Path) -> None:
     """Render a discovery report, or exit with the message its emptiness calls for.
 
     Distinguish "the directory holds no video files" (not an error) from "files were
     found but none matched" (an error), so a user can tell a bad path from a bad filter.
+    Read the query off the report rather than taking it as arguments, so the no-match
+    error can never name a filter set discovery did not actually apply.
 
     Args:
-        report (DiscoveryReport): The selection to present.
+        report (DiscoveryReport): The selection to present, carrying the query that
+            produced it.
         root (Path): The directory that was searched, named in the empty-directory warning.
-        filters (set[VideoTrait]): The active trait filters, named in the no-match error.
-        recursive (bool): Whether the search descended, so rows can show their directory.
 
     Raises:
         cappa.Exit: With code 0 when no video files exist under `root`, or code 1 when
@@ -60,7 +54,7 @@ def present_discovery(
         # The table caption is the sole reporter of the skipped count on the success
         # path, but it never renders here, so fold the count into the error instead of
         # leaving the user unable to tell "nothing matches" from "nothing was readable".
-        human_readable_filters = ", ".join(f"'{f.value}'" for f in filters)
+        human_readable_filters = ", ".join(f"'{f.value}'" for f in report.filters)
         message = (
             f"No video files found matching {human_readable_filters}"
             if human_readable_filters
@@ -72,7 +66,7 @@ def present_discovery(
         raise cappa.Exit(code=1)
 
     pp.console().print(
-        search_table(report, root=root.expanduser().resolve() if recursive else None)
+        search_table(report, root=root.expanduser().resolve() if report.recursive else None)
     )
 
 

--- a/src/vid_cleaner/cli/discovery_output.py
+++ b/src/vid_cleaner/cli/discovery_output.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 
 import cappa
 from nclutils import pp
+from rich.filesize import decimal
+from rich.prompt import Confirm
 
 from vid_cleaner.views import search_table
 
@@ -71,3 +73,30 @@ def present_discovery(
     pp.console().print(
         search_table(report, root=root.expanduser().resolve() if recursive else None)
     )
+
+
+def confirm_selection(report: DiscoveryReport, *, assume_yes: bool) -> None:
+    """Ask the user to approve a discovered selection before acting on it.
+
+    Guard the expensive, file-rewriting half of a discovery run, and refuse to act on a
+    non-interactive terminal rather than blocking forever on a prompt nobody can answer.
+
+    Args:
+        report (DiscoveryReport): The selection awaiting approval.
+        assume_yes (bool): Skip the prompt and proceed.
+
+    Raises:
+        cappa.Exit: With code 1 when the terminal is not interactive and `assume_yes`
+            is False, or code 0 when the user declines.
+    """
+    if assume_yes:
+        return
+
+    if not pp.console().is_terminal:
+        pp.error("Refusing to run without a confirmation prompt. Pass `--yes` to proceed.")
+        raise cappa.Exit(code=1)
+
+    total_size = decimal(sum(result.size for result in report.results))
+    if not Confirm.ask(f"Clean these {len(report.results)} files ({total_size})?", default=False):
+        pp.info("Nothing to do")
+        raise cappa.Exit(code=0)

--- a/src/vid_cleaner/cli/discovery_output.py
+++ b/src/vid_cleaner/cli/discovery_output.py
@@ -1,0 +1,73 @@
+"""Shared presentation of discovery results for `search` and `clean`.
+
+Keep this the only caller of `search_table` so the selection `clean` previews is the
+same rendering `search` prints, by construction rather than by convention.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import cappa
+from nclutils import pp
+
+from vid_cleaner.views import search_table
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from vid_cleaner.constants import VideoTrait
+    from vid_cleaner.controllers.discovery import DiscoveryReport
+
+
+def present_discovery(
+    report: DiscoveryReport,
+    *,
+    root: Path,
+    filters: set[VideoTrait],
+    recursive: bool,
+) -> None:
+    """Render a discovery report, or exit with the message its emptiness calls for.
+
+    Distinguish "the directory holds no video files" (not an error) from "files were
+    found but none matched" (an error), so a user can tell a bad path from a bad filter.
+
+    Args:
+        report (DiscoveryReport): The selection to present.
+        root (Path): The directory that was searched, named in the empty-directory warning.
+        filters (set[VideoTrait]): The active trait filters, named in the no-match error.
+        recursive (bool): Whether the search descended, so rows can show their directory.
+
+    Raises:
+        cappa.Exit: With code 0 when no video files exist under `root`, or code 1 when
+            files were found but none survived the filters.
+    """
+    if report.total == 0:
+        pp.warning(f"No video files found in {root}")
+        raise cappa.Exit(code=0)
+
+    if report.skipped:
+        pp.debug(
+            "Unreadable files",
+            details=[f"{e.path}: {e.reason}" for e in report.skipped],
+            markup=False,
+        )
+
+    if not report.results:
+        # The table caption is the sole reporter of the skipped count on the success
+        # path, but it never renders here, so fold the count into the error instead of
+        # leaving the user unable to tell "nothing matches" from "nothing was readable".
+        human_readable_filters = ", ".join(f"'{f.value}'" for f in filters)
+        message = (
+            f"No video files found matching {human_readable_filters}"
+            if human_readable_filters
+            else "No video files could be read"
+        )
+        if report.skipped:
+            message += f" ({len(report.skipped)} file(s) skipped as unreadable)"
+        pp.error(message)
+        raise cappa.Exit(code=1)
+
+    pp.console().print(
+        search_table(report, root=root.expanduser().resolve() if recursive else None)
+    )

--- a/src/vid_cleaner/cli/discovery_output.py
+++ b/src/vid_cleaner/cli/discovery_output.py
@@ -70,6 +70,16 @@ def present_discovery(report: DiscoveryReport, *, root: Path) -> None:
     )
 
 
+def _no_prompt_available() -> cappa.Exit:
+    """Report that the run cannot be confirmed and build the exit to raise.
+
+    Returns:
+        cappa.Exit: The failure to raise at the call site.
+    """
+    pp.error("Refusing to run without a confirmation prompt. Pass `--yes` to proceed.")
+    return cappa.Exit(code=1)
+
+
 def confirm_selection(report: DiscoveryReport, *, assume_yes: bool) -> None:
     """Ask the user to approve a discovered selection before acting on it.
 
@@ -88,8 +98,7 @@ def confirm_selection(report: DiscoveryReport, *, assume_yes: bool) -> None:
         return
 
     if not pp.console().is_terminal:
-        pp.error("Refusing to run without a confirmation prompt. Pass `--yes` to proceed.")
-        raise cappa.Exit(code=1)
+        raise _no_prompt_available()
 
     total_size = decimal(sum(result.size for result in report.results))
     # This prompt is the only gate on a whole library, and `--overwrite` leaves no backup
@@ -100,6 +109,13 @@ def confirm_selection(report: DiscoveryReport, *, assume_yes: bool) -> None:
         else "keeping a timestamped backup of each original"
     )
     prompt = f"Clean these {len(report.results)} files ({total_size}) {recovery}?"
-    if not Confirm.ask(prompt, default=False):
+    try:
+        approved = Confirm.ask(prompt, default=False, console=pp.console())
+    # `is_terminal` describes the output stream, so a run with a terminal on stdout but a
+    # closed or redirected stdin reaches the prompt and gets EOF instead of an answer.
+    except EOFError as e:
+        raise _no_prompt_available() from e
+
+    if not approved:
         pp.info("Nothing to do")
         raise cappa.Exit(code=0)

--- a/src/vid_cleaner/cli/discovery_output.py
+++ b/src/vid_cleaner/cli/discovery_output.py
@@ -13,6 +13,7 @@ from nclutils import pp
 from rich.filesize import decimal
 from rich.prompt import Confirm
 
+from vid_cleaner import settings
 from vid_cleaner.views import search_table
 
 if TYPE_CHECKING:
@@ -97,6 +98,14 @@ def confirm_selection(report: DiscoveryReport, *, assume_yes: bool) -> None:
         raise cappa.Exit(code=1)
 
     total_size = decimal(sum(result.size for result in report.results))
-    if not Confirm.ask(f"Clean these {len(report.results)} files ({total_size})?", default=False):
+    # This prompt is the only gate on a whole library, and `--overwrite` leaves no backup
+    # to restore from, so it has to say which of the two it is about to do.
+    recovery = (
+        "in place with no backup"
+        if settings.overwrite
+        else "keeping a timestamped backup of each original"
+    )
+    prompt = f"Clean these {len(report.results)} files ({total_size}) {recovery}?"
+    if not Confirm.ask(prompt, default=False):
         pp.info("Nothing to do")
         raise cappa.Exit(code=0)

--- a/src/vid_cleaner/cli/search.py
+++ b/src/vid_cleaner/cli/search.py
@@ -1,12 +1,11 @@
 """Search subcommand."""
 
 import cappa
-from nclutils import pp
 
+from vid_cleaner.cli.discovery_output import present_discovery
 from vid_cleaner.config import settings
 from vid_cleaner.controllers.discovery import discover_video_files
 from vid_cleaner.vidcleaner import SearchCommand
-from vid_cleaner.views import search_table
 
 
 def main(search_cmd: SearchCommand) -> None:
@@ -18,51 +17,21 @@ def main(search_cmd: SearchCommand) -> None:
     Raises:
         cappa.Exit: Always, carrying the command's exit code.
     """
-    human_readable_filters = ", ".join(f"'{f.value}'" for f in settings.filters)
+    filters = set(settings.filters)
 
     report = discover_video_files(
         search_cmd.directory,
         depth=search_cmd.depth,
-        filters=set(settings.filters),
+        filters=filters,
         sort=search_cmd.sort,
         reverse=search_cmd.reverse,
     )
 
-    if report.total == 0:
-        pp.warning(f"No video files found in {search_cmd.directory}")
-        raise cappa.Exit(code=0)
-
-    if report.skipped:
-        pp.debug(
-            "Unreadable files",
-            details=[f"{e.path}: {e.reason}" for e in report.skipped],
-            markup=False,
-        )
-
-    if not report.results:
-        # The table caption is the sole reporter of the skipped count on the success
-        # path, but it never renders here, so fold the count into the error instead of
-        # leaving the user unable to tell "nothing matches" from "nothing was readable".
-        message = (
-            f"No video files found matching {human_readable_filters}"
-            if human_readable_filters
-            else "No video files could be read"
-        )
-        if report.skipped:
-            message += f" ({len(report.skipped)} file(s) skipped as unreadable)"
-        pp.error(message)
-        raise cappa.Exit(code=1)
-
-    pp.console().print(
-        search_table(
-            report.results,
-            sort=report.sort,
-            descending=report.descending,
-            total=report.total,
-            skipped=len(report.skipped),
-            filtered=report.filtered,
-            root=search_cmd.directory.expanduser().resolve() if search_cmd.depth > 0 else None,
-        )
+    present_discovery(
+        report,
+        root=search_cmd.directory,
+        filters=filters,
+        recursive=search_cmd.depth > 0,
     )
 
     raise cappa.Exit(code=0)

--- a/src/vid_cleaner/cli/search.py
+++ b/src/vid_cleaner/cli/search.py
@@ -21,17 +21,18 @@ def main(search_cmd: SearchCommand) -> None:
 
     report = discover_video_files(
         search_cmd.directory,
-        depth=search_cmd.depth,
+        depth=search_cmd.discovery.depth,
         filters=filters,
-        sort=search_cmd.sort,
-        reverse=search_cmd.reverse,
+        sort=search_cmd.discovery.sort,
+        reverse=search_cmd.discovery.reverse,
+        limit=search_cmd.discovery.limit,
     )
 
     present_discovery(
         report,
         root=search_cmd.directory,
         filters=filters,
-        recursive=search_cmd.depth > 0,
+        recursive=search_cmd.discovery.depth > 0,
     )
 
     raise cappa.Exit(code=0)

--- a/src/vid_cleaner/cli/search.py
+++ b/src/vid_cleaner/cli/search.py
@@ -17,22 +17,15 @@ def main(search_cmd: SearchCommand) -> None:
     Raises:
         cappa.Exit: Always, carrying the command's exit code.
     """
-    filters = set(settings.filters)
-
     report = discover_video_files(
         search_cmd.directory,
         depth=search_cmd.discovery.depth,
-        filters=filters,
+        filters=set(settings.filters),
         sort=search_cmd.discovery.sort,
         reverse=search_cmd.discovery.reverse,
         limit=search_cmd.discovery.limit,
     )
 
-    present_discovery(
-        report,
-        root=search_cmd.directory,
-        filters=filters,
-        recursive=search_cmd.discovery.depth > 0,
-    )
+    present_discovery(report, root=search_cmd.directory)
 
     raise cappa.Exit(code=0)

--- a/src/vid_cleaner/cli/search.py
+++ b/src/vid_cleaner/cli/search.py
@@ -1,48 +1,12 @@
 """Search subcommand."""
 
-from collections.abc import Callable
-from typing import Any
-
 import cappa
 from nclutils import pp
-from nclutils.fs import find_files, find_subdirectories
-from rich.live import Live
-from rich.progress import track
 
 from vid_cleaner.config import settings
-from vid_cleaner.constants import SortOrder, VideoContainerTypes
-from vid_cleaner.exceptions import VideoProbeError
-from vid_cleaner.models import SearchResult
-from vid_cleaner.utils import coerce_video_files
+from vid_cleaner.controllers.discovery import discover_video_files
 from vid_cleaner.vidcleaner import SearchCommand
 from vid_cleaner.views import search_table
-
-# Each key pairs a getter with the direction that reads naturally for it: names ascend,
-# magnitudes descend. `--reverse` flips whichever is active.
-SortKey = Callable[[SearchResult], Any]
-SORT_KEYS: dict[SortOrder, tuple[SortKey, bool]] = {
-    SortOrder.ALPHA: (lambda result: str(result.video_file.path).lower(), False),
-    SortOrder.SIZE: (lambda result: result.size, True),
-    SortOrder.BITRATE: (lambda result: result.bitrate, True),
-}
-
-
-def coerce_bitrate(raw: str | int | None) -> int:
-    """Convert an ffprobe bit_rate value to an integer, falling back to zero.
-
-    ffprobe reports bit_rate as a string and omits it entirely for some containers, so
-    sorting needs a total order that a missing value cannot break.
-
-    Args:
-        raw (str | int | None): The `bit_rate` value from a probe box.
-
-    Returns:
-        int: The bitrate in bits per second, or 0 when it is missing or unparsable.
-    """
-    try:
-        return int(raw)
-    except (TypeError, ValueError):
-        return 0
 
 
 def main(search_cmd: SearchCommand) -> None:
@@ -52,87 +16,30 @@ def main(search_cmd: SearchCommand) -> None:
         search_cmd (SearchCommand): The search command instance with search-specific options
 
     Raises:
-        cappa.Exit: If no video files are found
+        cappa.Exit: Always, carrying the command's exit code.
     """
     human_readable_filters = ", ".join(f"'{f.value}'" for f in settings.filters)
 
-    directories_to_search = (
-        [*find_subdirectories(search_cmd.directory, depth=search_cmd.depth), search_cmd.directory]
-        if search_cmd.depth > 0
-        else [search_cmd.directory]
+    report = discover_video_files(
+        search_cmd.directory,
+        depth=search_cmd.depth,
+        filters=set(settings.filters),
+        sort=search_cmd.sort,
+        reverse=search_cmd.reverse,
     )
 
-    video_files = []
-
-    with Live(console=pp.console(), auto_refresh=True) as live:
-        for i, directory in enumerate(directories_to_search):
-            video_files.extend(
-                coerce_video_files(
-                    find_files(
-                        directory,
-                        globs=[
-                            f"*{container_type.value}" for container_type in VideoContainerTypes
-                        ],
-                    )
-                )
-            )
-            live.update(
-                f"Found {len(video_files)} video files in {i + 1}/{len(directories_to_search)} directories"
-            )
-
-        live.update(
-            f"[dim]Found {len(video_files)} video files in {i + 1}/{len(directories_to_search)} directories[/dim]"
-        )
-        live.stop()
-
-    if len(video_files) == 0:
+    if report.total == 0:
         pp.warning(f"No video files found in {search_cmd.directory}")
         raise cappa.Exit(code=0)
 
-    results: list[SearchResult] = []
-    unreadable: list[VideoProbeError] = []
-    for video_file in track(
-        video_files,
-        description=f"Filtering {len(video_files)} files for {human_readable_filters}...",
-        transient=True,
-    ):
-        # A video extension is no guarantee of video content; corrupt files and stubs like
-        # AppleDouble `._` sidecars must not abort the whole search.
-        try:
-            video_traits = video_file.get_traits()
-        except VideoProbeError as e:
-            unreadable.append(e)
-            continue
-
-        matches = [trait for trait in video_traits if trait in settings.filters]
-        if settings.filters and not matches:
-            continue
-
-        # A file that vanishes between the probe above and this stat() (e.g. deleted by
-        # another process mid-scan) must not abort a batch search that may have already
-        # spent minutes probing the rest of the library.
-        try:
-            size = video_file.path.stat().st_size
-        except OSError as e:
-            unreadable.append(VideoProbeError(path=video_file.path, reason=str(e)))
-            continue
-
-        results.append(
-            SearchResult(
-                video_file=video_file,
-                traits=video_traits,
-                matches=matches,
-                size=size,
-                bitrate=coerce_bitrate(video_file.probe_box.bit_rate),
-            )
-        )
-
-    if unreadable:
+    if report.skipped:
         pp.debug(
-            "Unreadable files", details=[f"{e.path}: {e.reason}" for e in unreadable], markup=False
+            "Unreadable files",
+            details=[f"{e.path}: {e.reason}" for e in report.skipped],
+            markup=False,
         )
 
-    if not results:
+    if not report.results:
         # The table caption is the sole reporter of the skipped count on the success
         # path, but it never renders here, so fold the count into the error instead of
         # leaving the user unable to tell "nothing matches" from "nothing was readable".
@@ -141,28 +48,19 @@ def main(search_cmd: SearchCommand) -> None:
             if human_readable_filters
             else "No video files could be read"
         )
-        if unreadable:
-            message += f" ({len(unreadable)} file(s) skipped as unreadable)"
+        if report.skipped:
+            message += f" ({len(report.skipped)} file(s) skipped as unreadable)"
         pp.error(message)
         raise cappa.Exit(code=1)
 
-    # Presort by path so ties on the active key (e.g. every bitrate-less file) resolve
-    # deterministically instead of reflecting find_files' arbitrary scan order. `sort`
-    # is stable, so this ordering survives as the tiebreaker after the real sort below.
-    results.sort(key=SORT_KEYS[SortOrder.ALPHA][0])
-
-    key_fn, descends_by_default = SORT_KEYS[search_cmd.sort]
-    descending = descends_by_default != search_cmd.reverse
-    results.sort(key=key_fn, reverse=descending)
-
     pp.console().print(
         search_table(
-            results,
-            sort=search_cmd.sort,
-            descending=descending,
-            total=len(video_files),
-            skipped=len(unreadable),
-            filtered=bool(settings.filters),
+            report.results,
+            sort=report.sort,
+            descending=report.descending,
+            total=report.total,
+            skipped=len(report.skipped),
+            filtered=report.filtered,
             root=search_cmd.directory.expanduser().resolve() if search_cmd.depth > 0 else None,
         )
     )

--- a/src/vid_cleaner/constants.py
+++ b/src/vid_cleaner/constants.py
@@ -101,7 +101,7 @@ class Resolution:
 
 
 SYMBOL_CHECK = "✔"
-SYMBOL_CROSS = "✖"  # Marks a requested operation that was skipped, in debug output
+SYMBOL_CROSS = "✖"  # Marks a skipped operation in debug output, or a file that failed to process
 # Shared so the VP9 planner can correct the subtitle action recorded under this exact label
 DROP_SUBTITLES_LABEL = "Drop unwanted subtitles"
 TREE_BRANCH = "├─"  # Connector for a non-final child line in faked step output

--- a/src/vid_cleaner/controllers/__init__.py
+++ b/src/vid_cleaner/controllers/__init__.py
@@ -1,5 +1,8 @@
 """Controllers for the VidCleaner application."""
 
+# `discovery` is deliberately absent: it imports `vid_cleaner.models`, which imports this
+# package, so re-exporting it here to match `temp_files` makes both unimportable. Import it
+# as `vid_cleaner.controllers.discovery` instead.
 from .temp_files import TempFile
 
 __all__ = ["TempFile"]

--- a/src/vid_cleaner/controllers/discovery.py
+++ b/src/vid_cleaner/controllers/discovery.py
@@ -31,8 +31,8 @@ SORT_KEYS: dict[SortOrder, tuple[SortKey, bool]] = {
 class DiscoveryReport:
     """The outcome of one discovery run, carrying everything a caller needs to render or act.
 
-    Hold the active sort state alongside the rows so a renderer's header arrow and caption
-    cannot disagree with the order the rows are actually in.
+    Hold the active query and sort state alongside the rows so a renderer's header arrow,
+    caption, and error messages cannot disagree with the query that produced the rows.
     """
 
     results: list[SearchResult]
@@ -41,7 +41,26 @@ class DiscoveryReport:
     truncated: int
     sort: SortOrder
     descending: bool
-    filtered: bool
+    filters: set[VideoTrait]
+    depth: int
+
+    @property
+    def filtered(self) -> bool:
+        """Report whether any trait filter narrowed the selection.
+
+        Returns:
+            bool: True when at least one filter was applied.
+        """
+        return bool(self.filters)
+
+    @property
+    def recursive(self) -> bool:
+        """Report whether the search descended below its root.
+
+        Returns:
+            bool: True when subdirectories were searched.
+        """
+        return self.depth > 0
 
 
 def coerce_bitrate(raw: str | int | None) -> int:
@@ -174,5 +193,6 @@ def discover_video_files(
         truncated=truncated,
         sort=sort,
         descending=descending,
-        filtered=bool(active_filters),
+        filters=active_filters,
+        depth=depth,
     )

--- a/src/vid_cleaner/controllers/discovery.py
+++ b/src/vid_cleaner/controllers/discovery.py
@@ -1,0 +1,178 @@
+"""Discover, probe, filter, and rank video files under a directory."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003
+from typing import Any
+
+from nclutils import pp
+from nclutils.fs import find_files, find_subdirectories
+from rich.live import Live
+from rich.progress import track
+
+from vid_cleaner.constants import SortOrder, VideoContainerTypes, VideoTrait
+from vid_cleaner.exceptions import VideoProbeError
+from vid_cleaner.models import SearchResult
+from vid_cleaner.utils import coerce_video_files
+
+# Each key pairs a getter with the direction that reads naturally for it: names ascend,
+# magnitudes descend. `reverse` flips whichever is active.
+SortKey = Callable[[SearchResult], Any]
+SORT_KEYS: dict[SortOrder, tuple[SortKey, bool]] = {
+    SortOrder.ALPHA: (lambda result: str(result.video_file.path).lower(), False),
+    SortOrder.SIZE: (lambda result: result.size, True),
+    SortOrder.BITRATE: (lambda result: result.bitrate, True),
+}
+
+
+@dataclass
+class DiscoveryReport:
+    """The outcome of one discovery run, carrying everything a caller needs to render or act.
+
+    Hold the active sort state alongside the rows so a renderer's header arrow and caption
+    cannot disagree with the order the rows are actually in.
+    """
+
+    results: list[SearchResult]
+    total: int
+    skipped: list[VideoProbeError]
+    truncated: int
+    sort: SortOrder
+    descending: bool
+    filtered: bool
+
+
+def coerce_bitrate(raw: str | int | None) -> int:
+    """Convert an ffprobe bit_rate value to an integer, falling back to zero.
+
+    ffprobe reports bit_rate as a string and omits it entirely for some containers, so
+    sorting needs a total order that a missing value cannot break.
+
+    Args:
+        raw (str | int | None): The `bit_rate` value from a probe box.
+
+    Returns:
+        int: The bitrate in bits per second, or 0 when it is missing or unparsable.
+    """
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def discover_video_files(
+    root: Path,
+    *,
+    depth: int = 0,
+    filters: set[VideoTrait] | None = None,
+    sort: SortOrder = SortOrder.ALPHA,
+    reverse: bool = False,
+    limit: int | None = None,
+) -> DiscoveryReport:
+    """Find, probe, filter, and rank the video files under a directory.
+
+    Use this wherever a command needs to act on a set of files the user described by
+    query rather than by path, so `search` and `clean` always select identically.
+
+    Args:
+        root (Path): Directory to search.
+        depth (int): Subdirectory levels to descend. 0 searches only `root`.
+        filters (set[VideoTrait] | None): Traits a file must have at least one of. None or
+            an empty set keeps every readable file.
+        sort (SortOrder): Key to rank results by.
+        reverse (bool): Flip the key's natural direction.
+        limit (int | None): Keep only the first N results after sorting.
+
+    Returns:
+        DiscoveryReport: The ranked selection plus the counts needed to describe it.
+    """
+    active_filters = filters or set()
+    human_readable_filters = ", ".join(f"'{f.value}'" for f in active_filters)
+
+    directories_to_search = [*find_subdirectories(root, depth=depth), root] if depth > 0 else [root]
+
+    video_files = []
+    with Live(console=pp.console(), auto_refresh=True) as live:
+        for i, directory in enumerate(directories_to_search):
+            video_files.extend(
+                coerce_video_files(
+                    find_files(
+                        directory,
+                        globs=[
+                            f"*{container_type.value}" for container_type in VideoContainerTypes
+                        ],
+                    )
+                )
+            )
+            live.update(
+                f"Found {len(video_files)} video files in {i + 1}/{len(directories_to_search)} directories"
+            )
+
+        live.update(
+            f"[dim]Found {len(video_files)} video files in {i + 1}/{len(directories_to_search)} directories[/dim]"
+        )
+        live.stop()
+
+    results: list[SearchResult] = []
+    unreadable: list[VideoProbeError] = []
+    for video_file in track(
+        video_files,
+        description=f"Filtering {len(video_files)} files for {human_readable_filters}...",
+        transient=True,
+    ):
+        # A video extension is no guarantee of video content; corrupt files and stubs like
+        # AppleDouble `._` sidecars must not abort the whole run.
+        try:
+            video_traits = video_file.get_traits()
+        except VideoProbeError as e:
+            unreadable.append(e)
+            continue
+
+        matches = [trait for trait in video_traits if trait in active_filters]
+        if active_filters and not matches:
+            continue
+
+        # A file that vanishes between the probe above and this stat() (e.g. deleted by
+        # another process mid-scan) must not abort a run that may have already spent
+        # minutes probing the rest of the library.
+        try:
+            size = video_file.path.stat().st_size
+        except OSError as e:
+            unreadable.append(VideoProbeError(path=video_file.path, reason=str(e)))
+            continue
+
+        results.append(
+            SearchResult(
+                video_file=video_file,
+                traits=video_traits,
+                matches=matches,
+                size=size,
+                bitrate=coerce_bitrate(video_file.probe_box.bit_rate),
+            )
+        )
+
+    # Presort by path so ties on the active key (e.g. every bitrate-less file) resolve
+    # deterministically instead of reflecting find_files' arbitrary scan order. `sort`
+    # is stable, so this ordering survives as the tiebreaker after the real sort below.
+    results.sort(key=SORT_KEYS[SortOrder.ALPHA][0])
+
+    key_fn, descends_by_default = SORT_KEYS[sort]
+    descending = descends_by_default != reverse
+    results.sort(key=key_fn, reverse=descending)
+
+    truncated = 0
+    if limit is not None and limit < len(results):
+        truncated = len(results) - limit
+        results = results[:limit]
+
+    return DiscoveryReport(
+        results=results,
+        total=len(video_files),
+        skipped=unreadable,
+        truncated=truncated,
+        sort=sort,
+        descending=descending,
+        filtered=bool(active_filters),
+    )

--- a/src/vid_cleaner/controllers/temp_files.py
+++ b/src/vid_cleaner/controllers/temp_files.py
@@ -1,5 +1,6 @@
 """Manage temporary files."""
 
+import atexit
 import uuid
 from pathlib import Path
 
@@ -8,10 +9,24 @@ from nclutils import pp
 from vid_cleaner import settings
 
 
+def cleanup_on_exit(temp_file: "TempFile") -> None:  # pragma: no cover
+    """Remove a temp directory when the interpreter exits.
+
+    Resolve `clean_up` at exit rather than binding it at registration so the hook always
+    calls the method the instance carries at the time it runs.
+
+    Args:
+        temp_file (TempFile): The instance whose temporary files should be removed.
+    """
+    temp_file.clean_up()
+
+
 class TempFile:
     """Manage temporary files created during video processing.
 
     This class handles the creation, tracking, and cleanup of temporary files generated during video processing operations. It maintains a unique temporary directory for each instance and manages file naming and cleanup.
+
+    Once the instance creates its first temporary file it also registers an exit hook, so a full-size intermediate is removed even when the process dies partway through.
 
     Args:
         path (Path): The path to the original video file.
@@ -35,6 +50,7 @@ class TempFile:
         self.tmp_dir = settings.CACHE_DIR / uuid.uuid4().hex
         self.created_tmp_files: list[Path] = []
         self.tmp_file_number = 1
+        self._cleanup_registered = False
 
     def latest_temp_path(self) -> Path:
         """Get the path to the most recently created temporary file.
@@ -52,6 +68,7 @@ class TempFile:
 
         Creates a new unique path for a temporary file in the temp directory. The path
         will include an incrementing number and optional step name in the filename.
+        Registers the exit-time cleanup of this instance's temp directory on first use.
 
         Args:
             suffix (str | None, optional): File extension to use. Defaults to original file's suffix.
@@ -63,6 +80,13 @@ class TempFile:
         # Get the output file name
         suffix = suffix or self.suffix
         self.tmp_dir.mkdir(parents=True, exist_ok=True)
+
+        # Register only once there is something to clean up. A discovery run builds a
+        # TempFile for every candidate it probes, and an interpreter-lifetime hook on each
+        # one would pin thousands of files in memory to act on a handful.
+        if not self._cleanup_registered:
+            atexit.register(cleanup_on_exit, self)
+            self._cleanup_registered = True
 
         if not step_name:
             step_name = "no_step"

--- a/src/vid_cleaner/controllers/temp_files.py
+++ b/src/vid_cleaner/controllers/temp_files.py
@@ -18,7 +18,12 @@ def cleanup_on_exit(temp_file: "TempFile") -> None:  # pragma: no cover
     Args:
         temp_file (TempFile): The instance whose temporary files should be removed.
     """
-    temp_file.clean_up()
+    try:
+        temp_file.clean_up()
+    except OSError as e:
+        # An exit hook that raises turns an already-reported, already-exited command into
+        # an `atexit._run_exitfuncs` traceback on stderr. Leftover temp files are cheaper.
+        pp.debug(f"Could not clean up {temp_file.tmp_dir}: {e}")
 
 
 class TempFile:

--- a/src/vid_cleaner/exceptions.py
+++ b/src/vid_cleaner/exceptions.py
@@ -2,7 +2,25 @@
 
 from pathlib import Path
 
-__all__ = ["VideoProbeError"]
+__all__ = ["VideoCleanError", "VideoProbeError"]
+
+
+class VideoCleanError(Exception):
+    """Raised when one file cannot be cleaned, so a batch can skip it and continue.
+
+    Distinct from `cappa.Exit`, which means the whole run should stop.
+    """
+
+    def __init__(self, path: Path, reason: str) -> None:
+        """Initialize VideoCleanError.
+
+        Args:
+            path (Path): The file that could not be cleaned.
+            reason (str): Short explanation of why the file could not be cleaned.
+        """
+        self.path = path
+        self.reason = reason
+        super().__init__(f"Could not clean '{path}': {reason}")
 
 
 class VideoProbeError(Exception):

--- a/src/vid_cleaner/models/video_file.py
+++ b/src/vid_cleaner/models/video_file.py
@@ -748,7 +748,9 @@ class VideoFile:
         )
 
         debug = int(settings.get("verbosity", 0) or 0) >= 1
-        render_operations(plan.actions, debug=debug)
+        # A real run always follows these with write-outcome substeps, so leave the tree
+        # open for them; a dry run writes nothing, making the operations its last lines.
+        render_operations(plan.actions, debug=debug, closes_tree=bool(settings.dryrun))
 
         # Nothing to encode: the up-front render already reported "No changes needed".
         if plan.is_noop(stream_count=len(self.all_streams)) and not needs_reorder:

--- a/src/vid_cleaner/models/video_file.py
+++ b/src/vid_cleaner/models/video_file.py
@@ -1,6 +1,5 @@
 """VideoFile model."""
 
-import atexit
 import re
 from pathlib import Path
 
@@ -49,15 +48,6 @@ from vid_cleaner.utils import (
 from vid_cleaner.controllers import TempFile  # isort: skip
 
 
-def cleanup_on_exit(video_file: "VideoFile") -> None:  # pragma: no cover
-    """Cleanup temporary files on exit.
-
-    Args:
-        video_file (VideoFile): The VideoFile object to perform cleanup on.
-    """
-    video_file.temp_file.clean_up()
-
-
 class VideoFile:
     """VideoFile model."""
 
@@ -80,8 +70,6 @@ class VideoFile:
         self._video_streams: list[Box] = []
         self._audio_streams: list[Box] = []
         self._subtitle_streams: list[Box] = []
-
-        atexit.register(cleanup_on_exit, self)
 
     @property
     def probe_box(self) -> Box:

--- a/src/vid_cleaner/models/video_file.py
+++ b/src/vid_cleaner/models/video_file.py
@@ -32,6 +32,7 @@ from vid_cleaner.constants import (
     CodecTypes,
     VideoTrait,
 )
+from vid_cleaner.exceptions import VideoCleanError
 from vid_cleaner.models.conversion_plan import ConversionPlan, OutputStream, PlanAction
 from vid_cleaner.utils import (
     MediaId,
@@ -739,14 +740,12 @@ class VideoFile:
                 caller to inspect.
 
         Raises:
-            cappa.Exit: If the file has no video or no audio streams.
+            VideoCleanError: If the file has no video or no audio streams.
         """
         if not self.video_streams:
-            pp.error("No video streams found")
-            raise cappa.Exit(code=1)
+            raise VideoCleanError(path=self.path, reason="no video streams found")
         if not self.audio_streams:
-            pp.error("No audio streams found")
-            raise cappa.Exit(code=1)
+            raise VideoCleanError(path=self.path, reason="no audio streams found")
 
         plan = self._build_plan()
 

--- a/src/vid_cleaner/utils/__init__.py
+++ b/src/vid_cleaner/utils/__init__.py
@@ -9,6 +9,7 @@ from .cli import (  # isort: skip
     coerce_video_files,
     copy_to_output,
     create_default_config,
+    parse_limit,
     parse_trait_filters,
     resolve_out_path_override,
 )
@@ -21,6 +22,7 @@ __all__ = [
     "create_default_config",
     "find_media_ids",
     "get_probe_as_box",
+    "parse_limit",
     "parse_trait_filters",
     "query_radarr",
     "query_sonarr",

--- a/src/vid_cleaner/utils/cli.py
+++ b/src/vid_cleaner/utils/cli.py
@@ -155,6 +155,29 @@ def create_default_config() -> None:
         pp.info(f"Default configuration file created: `{USER_CONFIG_PATH}`")
 
 
+def parse_limit(raw: str) -> int:
+    """Parse `--limit` as a count of results to keep, rejecting anything below one.
+
+    Reject the bad value at parse time because the limit reaches a list slice unchecked:
+    zero selects nothing and a negative value quietly trims from the end, so either one
+    acts on a selection the user never described.
+
+    Args:
+        raw (str): The raw command line value.
+
+    Returns:
+        int: The validated limit.
+
+    Raises:
+        ValueError: If the value is not a whole number of 1 or greater.
+    """
+    value = int(raw)
+    if value < 1:
+        msg = f"must be 1 or greater, got {value}"
+        raise ValueError(msg)
+    return value
+
+
 def parse_trait_filters(facets: str) -> set[VideoTrait]:
     """Parse a comma-separated list of facets into a list of VideoTrait enums.
 

--- a/src/vid_cleaner/utils/cli.py
+++ b/src/vid_cleaner/utils/cli.py
@@ -55,21 +55,27 @@ def coerce_video_files(files: list[Path]) -> list["VideoFile"]:
     return [VideoFile(path.expanduser().resolve().absolute()) for path in files]
 
 
-def resolve_out_path_override(files: list[Path]) -> Path | None:
+def resolve_out_path_override(
+    files: list[Path], *, from_directory: Path | None = None
+) -> Path | None:
     """Capture the explicit `--out` override before per-file processing mutates it.
 
-    Read `settings.out_path` once up front so the first file's resolved path can't leak into later files and overwrite them all with the first file's name. Reject a single `--out` paired with multiple inputs, since one path cannot name many outputs.
+    Read `settings.out_path` once up front so the first file's resolved path can't leak into later files and overwrite them all with the first file's name. Reject a single `--out` paired with a multi-file selection, since one path cannot name many outputs.
 
     Args:
         files (list[Path]): The input files the command will process.
+        from_directory (Path | None): The `--from` discovery root, when discovery mode is active.
 
     Returns:
         Path | None: The user's explicit `--out` value, or None when not set.
 
     Raises:
-        cappa.Exit: If `--out` is combined with more than one input file.
+        cappa.Exit: If `--out` is combined with more than one input file or with `--from`.
     """
     override = settings.out_path
+    if override and from_directory is not None:
+        pp.error("`--out` cannot be used with `--from`")
+        raise cappa.Exit(code=1)
     if override and len(files) > 1:
         pp.error("`--out` cannot be used with multiple input files")
         raise cappa.Exit(code=1)

--- a/src/vid_cleaner/utils/console.py
+++ b/src/vid_cleaner/utils/console.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from vid_cleaner.models.conversion_plan import PlanAction
 
 
-def _render_tree(lines: list[tuple[str, str]]) -> None:
+def _render_tree(lines: list[tuple[str, str]], *, closes_tree: bool) -> None:
     """Print styled lines beneath the current video as a faked ``pp`` sub-item tree.
 
     A real ``pp.step`` spinner recomputes the connector on each live refresh, but its
@@ -23,8 +23,10 @@ def _render_tree(lines: list[tuple[str, str]]) -> None:
     Args:
         lines: ``(message, style)`` pairs in display order; ``style`` is a Rich style
             applied to the message text (empty string for no styling).
+        closes_tree: Whether these are the last lines for the current video. When False
+            every line branches with ``├─``, so a later batch can close the same tree.
     """
-    last_index = len(lines) - 1
+    last_index = len(lines) - 1 if closes_tree else -1
     for index, (message, style) in enumerate(lines):
         connector = TREE_LAST if index == last_index else TREE_BRANCH
         # `sub.pipe` is nclutils' dim connector style, matching its own Step sub-items.
@@ -41,10 +43,10 @@ def render_substeps(messages: list[str]) -> None:
     Args:
         messages: Outcome lines to display beneath the current video, in order.
     """
-    _render_tree([(message, "") for message in messages])
+    _render_tree([(message, "") for message in messages], closes_tree=True)
 
 
-def render_operations(actions: list[PlanAction], *, debug: bool) -> None:
+def render_operations(actions: list[PlanAction], *, debug: bool, closes_tree: bool = True) -> None:
     """Render the cleaning operations for a file as a tree beneath its name.
 
     Print the truthful operation list up front, before the ffmpeg progress bar. In
@@ -55,6 +57,8 @@ def render_operations(actions: list[PlanAction], *, debug: bool) -> None:
     Args:
         actions: The plan's operations, in display order.
         debug: When True, also show skipped operations with their reason.
+        closes_tree: Whether the operations are all this video will print. Pass False when
+            outcome substeps follow, so the file renders as one tree rather than two.
     """
     visible = actions if debug else [action for action in actions if action.applied]
 
@@ -69,4 +73,4 @@ def render_operations(actions: list[PlanAction], *, debug: bool) -> None:
                 suffix = f"  ({action.reason})" if action.reason else ""
                 lines.append((f"{SYMBOL_CROSS} {action.label}{suffix}", "dim"))
 
-    _render_tree(lines)
+    _render_tree(lines, closes_tree=closes_tree)

--- a/src/vid_cleaner/vidcleaner.py
+++ b/src/vid_cleaner/vidcleaner.py
@@ -507,8 +507,8 @@ def main() -> None:  # pragma: no cover
         pp.info("\nExiting...")
         raise cappa.Exit(code=1) from e
     except VideoProbeError as e:
-        # Commands given explicit files abort on an unreadable one; `search` handles its own
-        # skipping before the error can reach here.
+        # Only `inspect` and `clip` reach this: `search` skips unreadable files itself, and
+        # `clean` catches this per file in its batch loop rather than letting it propagate.
         pp.error(str(e))
         raise cappa.Exit(code=1) from e
 

--- a/src/vid_cleaner/vidcleaner.py
+++ b/src/vid_cleaner/vidcleaner.py
@@ -14,7 +14,7 @@ from vid_cleaner import settings
 from vid_cleaner.config import SettingsManager
 from vid_cleaner.constants import USER_CONFIG_PATH, PrintLevel, SortOrder, VideoTrait
 from vid_cleaner.exceptions import VideoProbeError
-from vid_cleaner.utils import create_default_config, parse_trait_filters
+from vid_cleaner.utils import create_default_config, parse_limit, parse_trait_filters
 
 
 def config_subcommand(vidcleaner: VidCleaner) -> None:
@@ -121,6 +121,7 @@ class DiscoveryOptions:
             long=True,
             show_default=False,
             group="Discovery",
+            parse=parse_limit,
         ),
     ] = None
 
@@ -347,7 +348,7 @@ class CleanCommand:
     yes: Annotated[
         bool,
         cappa.Arg(
-            help="Skip the confirmation prompt when using `--from`",
+            help="Skip the confirmation prompt. Requires `--from`",
             long=True,
             short="-y",
             show_default=True,

--- a/src/vid_cleaner/vidcleaner.py
+++ b/src/vid_cleaner/vidcleaner.py
@@ -216,6 +216,9 @@ vidcleaner clean --h265 --langs=eng <video_file>
 
 # Downmix audio to stereo and keep all subtitles:
 vidcleaner clean --downmix --keep-subs <video_file>
+
+# Convert the five largest 4k files under a directory to H265:
+vidcleaner clean --from /media --filters=4k --sort=size --limit=5 --h265
 ```
     """,
 )
@@ -224,8 +227,17 @@ class CleanCommand:
 
     files: Annotated[
         list[Path],
-        cappa.Arg(help="Video file path(s)"),
-    ]
+        cappa.Arg(help="Video file path(s)", show_default=False),
+    ] = field(default_factory=list)
+    from_: Annotated[
+        Path | None,
+        cappa.Arg(
+            help="Directory to discover files in instead of naming them explicitly",
+            long="--from",
+            show_default=False,
+            group="Discovery",
+        ),
+    ] = None
     out: Annotated[
         Path | None,
         cappa.Arg(
@@ -332,6 +344,16 @@ class CleanCommand:
             show_default=True,
         ),
     ] = False
+    yes: Annotated[
+        bool,
+        cappa.Arg(
+            help="Skip the confirmation prompt when using `--from`",
+            long=True,
+            short="-y",
+            show_default=True,
+        ),
+    ] = False
+    discovery: cappa.Destructured[DiscoveryOptions] = field(default_factory=DiscoveryOptions)
 
 
 @cappa.command(

--- a/src/vid_cleaner/vidcleaner.py
+++ b/src/vid_cleaner/vidcleaner.py
@@ -242,7 +242,7 @@ class CleanCommand:
     out: Annotated[
         Path | None,
         cappa.Arg(
-            help="Output path (Default: `./<input_file>_1.xxx`)",
+            help="Output path (Default: replace the input file, keeping a timestamped `.bak` copy of the original)",
             long=True,
             short=True,
             show_default=False,
@@ -395,7 +395,7 @@ Clip a section from a video file.
 This command allows you to extract a specific portion of a video file based on start time and duration.
 
 * The start time and duration should be specified in `HH:MM:SS` format.
-* You can also specify an output file to save the clipped video. If the output file is not specified, the clip will be saved with a default naming convention.
+* Use `--out` to write the clip to a new file. Without it the clip replaces the input file, and the original is kept alongside it as a timestamped `.bak` copy.
 
 Use the `--overwrite` option to avoid creating a backup of the original file if it would be overwritten.
 """,
@@ -429,7 +429,7 @@ class ClipCommand:
     out: Annotated[
         Path | None,
         cappa.Arg(
-            help="Output file path (Default: `<input_file>_1`)",
+            help="Output file path (Default: replace the input file, keeping a timestamped `.bak` copy of the original)",
             long=True,
             short=True,
             show_default=False,

--- a/src/vid_cleaner/vidcleaner.py
+++ b/src/vid_cleaner/vidcleaner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Annotated
 
@@ -37,10 +38,11 @@ def config_subcommand(vidcleaner: VidCleaner) -> None:
     if langs_to_keep and isinstance(langs_to_keep, str):
         langs_to_keep = langs_to_keep.split(",")
 
-    if getattr(vidcleaner.command, "filters", None):
-        filters = parse_trait_filters(getattr(vidcleaner.command, "filters", None))
-    else:
-        filters = set()
+    # Discovery options are destructured onto a nested object shared by `search` and
+    # `clean`, so the raw filter string is one level down from the command itself.
+    discovery = getattr(vidcleaner.command, "discovery", None)
+    raw_filters = getattr(discovery, "filters", None)
+    filters = parse_trait_filters(raw_filters) if raw_filters else set()
 
     # Apply command-specific settings
     cli_settings = {
@@ -66,6 +68,61 @@ def config_subcommand(vidcleaner: VidCleaner) -> None:
     SettingsManager.apply_cli_settings(cli_settings)
 
     pp.trace("Settings", details=[settings.to_dict(), vidcleaner.__dict__])
+
+
+@dataclass
+class DiscoveryOptions:
+    """The query vocabulary shared by `search` and `clean`.
+
+    Composed into both commands so a `search` invocation and a `clean` invocation with
+    the same flags always select the same files.
+    """
+
+    depth: Annotated[
+        int,
+        cappa.Arg(
+            help="Depth to search for video files",
+            long=True,
+            show_default=False,
+            group="Discovery",
+        ),
+    ] = 0
+    filters: Annotated[
+        str | None,
+        cappa.Arg(
+            help=f"Comma separated list of facets to search for. Valid options: {VideoTrait.help_options()}",
+            long=True,
+            show_default=False,
+            group="Discovery",
+        ),
+    ] = None
+    sort: Annotated[
+        SortOrder,
+        cappa.Arg(
+            help="Sort results by name, file size, or bitrate.",
+            long=True,
+            show_default=True,
+            group="Discovery",
+        ),
+    ] = SortOrder.ALPHA
+    reverse: Annotated[
+        bool,
+        cappa.Arg(
+            help="Reverse the sort order",
+            long=True,
+            show_default=True,
+            group="Discovery",
+        ),
+    ] = False
+    limit: Annotated[
+        int | None,
+        cappa.Arg(
+            help="Act on only the first N results after sorting",
+            long=True,
+            show_default=False,
+            group="Discovery",
+        ),
+    ] = None
 
 
 @cappa.command(
@@ -399,6 +456,9 @@ vidcleaner search --filters=h264,1080p --depth=2
 
 # List 4k files, largest first:
 vidcleaner search --filters=4k --sort=size
+
+# List the 5 largest 4k files:
+vidcleaner search --filters=4k --sort=size --limit=5
 ```
 """,
     invoke="vid_cleaner.cli.search.main",
@@ -410,39 +470,7 @@ class SearchCommand:
         Path,
         cappa.Arg(help="Directory to search for video files", show_default=False),
     ] = Path.cwd()
-    depth: Annotated[
-        int,
-        cappa.Arg(
-            help="Depth to search for video files", long=True, short=False, show_default=False
-        ),
-    ] = 0
-    filters: Annotated[
-        str,
-        cappa.Arg(
-            help=f"Comma separated list of facets to search for. Valid options: {VideoTrait.help_options()}",
-            long=True,
-            short=False,
-            show_default=False,
-        ),
-    ] = None
-    sort: Annotated[
-        SortOrder,
-        cappa.Arg(
-            help="Sort results by name, file size, or bitrate.",
-            long=True,
-            short=False,
-            show_default=True,
-        ),
-    ] = SortOrder.ALPHA
-    reverse: Annotated[
-        bool,
-        cappa.Arg(
-            help="Reverse the sort order",
-            long=True,
-            short=False,
-            show_default=True,
-        ),
-    ] = False
+    discovery: cappa.Destructured[DiscoveryOptions] = field(default_factory=DiscoveryOptions)
 
 
 def main() -> None:  # pragma: no cover

--- a/src/vid_cleaner/views/tables.py
+++ b/src/vid_cleaner/views/tables.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
     from box import Box
 
     from vid_cleaner.constants import VideoTrait
+
+    # A view naming a controller type is fine as long as it stays type-only: the
+    # annotation buys the view no runtime dependency on the controller layer.
     from vid_cleaner.controllers.discovery import DiscoveryReport
 
 # Scene releases lead with the title and switch to release metadata at the year (movies) or

--- a/src/vid_cleaner/views/tables.py
+++ b/src/vid_cleaner/views/tables.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from box import Box
 
     from vid_cleaner.constants import VideoTrait
-    from vid_cleaner.models import SearchResult
+    from vid_cleaner.controllers.discovery import DiscoveryReport
 
 # Scene releases lead with the title and switch to release metadata at the year (movies) or
 # the season/episode token (TV). Everything after that point restates, in scene shorthand,
@@ -155,30 +155,15 @@ def sort_header(label: str, *, active: bool, descending: bool) -> Text:
     return Text(f"{label} {'↓' if descending else '↑'}", style="bold cyan")
 
 
-def search_table(  # noqa: PLR0913
-    results: list[SearchResult],
-    *,
-    sort: SortOrder,
-    descending: bool,
-    total: int,
-    skipped: int,
-    filtered: bool,
-    root: Path | None = None,
-) -> Table:
-    """Build the `search` results table.
+def search_table(report: DiscoveryReport, *, root: Path | None = None) -> Table:
+    """Build the discovery results table shared by `search` and `clean`.
 
     Stack each file's traits beneath its name inside one cell so the filename gets the
     table's full width instead of competing with a traits column, and so filter matches
     can be shown as emphasis rather than as a second column repeating the same tokens.
 
     Args:
-        results (list[SearchResult]): Matching files, already in display order.
-        sort (SortOrder): The active sort key, marked in the column headers.
-        descending (bool): Whether the rows run from largest to smallest on the active
-            key, so the header arrow can point the way the values actually run.
-        total (int): How many candidate video files were discovered.
-        skipped (int): How many files could not be read as video.
-        filtered (bool): Whether any trait filters were active.
+        report (DiscoveryReport): The ranked selection and the counts describing it.
         root (Path | None): The directory a recursive search started from. When set,
             each row's directory renders as a dim segment ahead of its filename so
             same-named files in different directories stay distinguishable. Omitted
@@ -187,8 +172,17 @@ def search_table(  # noqa: PLR0913
     Returns:
         Table: Rich table ready to print.
     """
-    summary = f"{len(results)} of {total} files matched" if filtered else f"{len(results)} files"
-    caption = f"{summary} · {skipped} skipped" if skipped else summary
+    matched = len(report.results) + report.truncated
+    summary = (
+        f"{matched} of {report.total} files matched" if report.filtered else f"{matched} files"
+    )
+
+    parts = [summary]
+    if report.truncated:
+        parts.insert(0, f"showing {len(report.results)}")
+    if report.skipped:
+        parts.append(f"{len(report.skipped)} skipped")
+    caption = " · ".join(parts)
 
     table = Table(
         box=box.SIMPLE_HEAD,
@@ -205,20 +199,23 @@ def search_table(  # noqa: PLR0913
     table.add_column("#", justify="right", style="dim", header_style="dim", no_wrap=True)
     # Fold rather than truncate: a clipped filename cannot identify a file.
     table.add_column(
-        sort_header("File", active=sort == SortOrder.ALPHA, descending=descending), overflow="fold"
+        sort_header("File", active=report.sort == SortOrder.ALPHA, descending=report.descending),
+        overflow="fold",
     )
     table.add_column(
-        sort_header("Size", active=sort == SortOrder.SIZE, descending=descending),
+        sort_header("Size", active=report.sort == SortOrder.SIZE, descending=report.descending),
         justify="right",
         no_wrap=True,
     )
     table.add_column(
-        sort_header("Bitrate", active=sort == SortOrder.BITRATE, descending=descending),
+        sort_header(
+            "Bitrate", active=report.sort == SortOrder.BITRATE, descending=report.descending
+        ),
         justify="right",
         no_wrap=True,
     )
 
-    for index, result in enumerate(results, start=1):
+    for index, result in enumerate(report.results, start=1):
         parent = ""
         if root is not None:
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for tests."""
 
+import copy
 import json
 from pathlib import Path
 
@@ -110,6 +111,42 @@ def mock_ffmpeg(mocker):
     mock_instance = mock_ffmpeg_progress.return_value
     mock_instance.run_command_with_progress.return_value = iter([0, 25, 50, 75, 100])
     return mock_ffmpeg_progress
+
+
+@pytest.fixture
+def video_library(tmp_path, mocker, mock_ffprobe_box):
+    """Build a directory of probeable video files with per-file size and bitrate.
+
+    Names may include a nested path, e.g. "aaa/mike.mkv", to exercise recursive
+    searches; the parent directory is created automatically.
+
+    Returns:
+        Callable[[list[tuple[str, int, int]]], Path]: Call with `(filename, size_bytes,
+            bitrate_bps)` triples to create the files and patch ffprobe to report the
+            matching bitrate for each one.
+    """
+
+    def _inner(files: list[tuple[str, int, int]]) -> Path:
+        reference = mock_ffprobe_box("reference.json")
+        directory = tmp_path / "library"
+        directory.mkdir(exist_ok=True)
+
+        boxes = {}
+        for name, size, bitrate in files:
+            path = directory / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"\0" * size)
+            file_box = copy.deepcopy(reference)
+            file_box.bit_rate = str(bitrate) if bitrate else None
+            boxes[name] = file_box
+
+        mocker.patch(
+            "vid_cleaner.models.video_file.get_probe_as_box",
+            side_effect=lambda path: boxes[path.relative_to(directory).as_posix()],
+        )
+        return directory
+
+    return _inner
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,9 @@ def video_library(tmp_path, mocker, mock_ffprobe_box):
             path.write_bytes(b"\0" * size)
             file_box = copy.deepcopy(reference)
             file_box.bit_rate = str(bitrate) if bitrate else None
+            # Real probe boxes carry the path they were built from, and `VideoFile`
+            # compares it to decide whether its cached probe is still current.
+            file_box.path_to_file = path
             boxes[name] = file_box
 
         mocker.patch(
@@ -168,6 +171,28 @@ def mock_probe_tags(mocker):
         mocker.patch(
             "vid_cleaner.models.video_file.get_probe_as_box",
             return_value=Box({"format": {"tags": tags or {}}}, default_box=True),
+        )
+
+    return _inner
+
+
+@pytest.fixture
+def interactive_console(mocker):
+    """Force `Console.is_terminal` so the prompt path can be exercised under pytest.
+
+    Patch the property on the class rather than replacing `pp.console`, which would hand
+    `pp.error` a mock and silently break stderr capture in these same tests.
+
+    Returns:
+        Callable[..., None]: Call with `is_terminal=True` or `is_terminal=False` to set
+            interactivity.
+    """
+
+    def _inner(*, is_terminal: bool) -> None:
+        mocker.patch(
+            "rich.console.Console.is_terminal",
+            new_callable=mocker.PropertyMock,
+            return_value=is_terminal,
         )
 
     return _inner

--- a/tests/controllers/test_discovery.py
+++ b/tests/controllers/test_discovery.py
@@ -1,0 +1,192 @@
+# type: ignore
+"""Test the discovery controller."""
+
+import pytest
+
+from vid_cleaner.constants import SortOrder, VideoTrait
+from vid_cleaner.controllers.discovery import DiscoveryReport, coerce_bitrate, discover_video_files
+from vid_cleaner.exceptions import VideoProbeError
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("5000000", 5_000_000), (5_000_000, 5_000_000), (None, 0), ("", 0), ("abc", 0)],
+)
+def test_coerce_bitrate(raw, expected):
+    """Verify ffprobe's string, integer, missing, and unparsable bitrates all yield an int."""
+    assert coerce_bitrate(raw) == expected
+
+
+def test_discover_returns_empty_report_for_empty_directory(tmp_path):
+    """Verify a directory with no video files reports zero total without raising."""
+    # Given: An empty directory
+    directory = tmp_path / "empty"
+    directory.mkdir()
+
+    # When: Discovering video files
+    report = discover_video_files(directory)
+
+    # Then: The report is empty rather than an exception or an exit
+    assert isinstance(report, DiscoveryReport)
+    assert report.total == 0
+    assert report.results == []
+    assert report.skipped == []
+
+
+def test_discover_reports_total_and_filters(video_library):
+    """Verify total counts every candidate while results hold only trait matches."""
+    # Given: Two probeable files, both h264 per the reference fixture
+    directory = video_library([("apple.mkv", 100, 1_000_000), ("banana.mkv", 200, 2_000_000)])
+
+    # When: Filtering for a trait both files have
+    report = discover_video_files(directory, filters={VideoTrait.H264})
+
+    # Then: Both files are counted and both match
+    assert report.total == 2
+    assert len(report.results) == 2
+    assert report.filtered is True
+
+
+def test_discover_without_filters_keeps_everything(video_library):
+    """Verify an empty filter set matches every readable file."""
+    # Given: Two probeable files
+    directory = video_library([("apple.mkv", 100, 1_000_000), ("banana.mkv", 200, 2_000_000)])
+
+    # When: Discovering with no filters
+    report = discover_video_files(directory)
+
+    # Then: Every file survives and the report says filtering was inactive
+    assert len(report.results) == 2
+    assert report.filtered is False
+
+
+@pytest.mark.parametrize(
+    ("sort", "reverse", "expected_order", "expected_descending"),
+    [
+        (SortOrder.ALPHA, False, ["apple.mkv", "banana.mkv", "cherry.mkv"], False),
+        (SortOrder.ALPHA, True, ["cherry.mkv", "banana.mkv", "apple.mkv"], True),
+        (SortOrder.SIZE, False, ["banana.mkv", "cherry.mkv", "apple.mkv"], True),
+        (SortOrder.SIZE, True, ["apple.mkv", "cherry.mkv", "banana.mkv"], False),
+        (SortOrder.BITRATE, False, ["cherry.mkv", "apple.mkv", "banana.mkv"], True),
+        (SortOrder.BITRATE, True, ["banana.mkv", "apple.mkv", "cherry.mkv"], False),
+    ],
+)
+def test_discover_sort_orders(video_library, sort, reverse, expected_order, expected_descending):
+    """Verify each sort key and reverse produce the documented order and direction."""
+    # Given: Three files whose alphabetical, size, and bitrate orders all differ
+    directory = video_library(
+        [
+            ("apple.mkv", 100, 2_000_000),
+            ("banana.mkv", 300, 1_000_000),
+            ("cherry.mkv", 200, 3_000_000),
+        ]
+    )
+
+    # When: Discovering with the given sort arguments
+    report = discover_video_files(directory, sort=sort, reverse=reverse)
+
+    # Then: The results run in the expected order and report their real direction
+    assert [r.video_file.path.name for r in report.results] == expected_order
+    assert report.descending is expected_descending
+
+
+def test_discover_limit_truncates_after_sorting(video_library):
+    """Verify limit keeps the top N on the active sort key and counts what it cut."""
+    # Given: Three files of differing size
+    directory = video_library(
+        [
+            ("apple.mkv", 100, 1_000_000),
+            ("banana.mkv", 300, 1_000_000),
+            ("cherry.mkv", 200, 1_000_000),
+        ]
+    )
+
+    # When: Taking the two largest
+    report = discover_video_files(directory, sort=SortOrder.SIZE, limit=2)
+
+    # Then: The two largest survive and the cut file is counted
+    assert [r.video_file.path.name for r in report.results] == ["banana.mkv", "cherry.mkv"]
+    assert report.truncated == 1
+    assert report.total == 3
+
+
+def test_discover_limit_above_match_count_truncates_nothing(video_library):
+    """Verify a limit larger than the match count is a no-op."""
+    # Given: Two files
+    directory = video_library([("apple.mkv", 100, 1_000_000), ("banana.mkv", 200, 1_000_000)])
+
+    # When: Limiting to more files than exist
+    report = discover_video_files(directory, limit=10)
+
+    # Then: Nothing is cut
+    assert len(report.results) == 2
+    assert report.truncated == 0
+
+
+def test_discover_collects_unreadable_files(video_library, mocker, tmp_path):
+    """Verify a file that cannot be probed is collected rather than aborting discovery."""
+    # Given: One readable file and one that ffprobe rejects
+    directory = video_library([("good.mkv", 100, 1_000_000)])
+    bad = directory / "bad.mkv"
+    bad.touch()
+    good_box = mocker.MagicMock()
+
+    def probe(path):
+        if path.name == "bad.mkv":
+            raise VideoProbeError(path=path, reason="Invalid data found when processing input")
+        return good_box
+
+    mocker.patch("vid_cleaner.models.video_file.get_probe_as_box", side_effect=probe)
+
+    # When: Discovering with no filters, so the readable file survives
+    report = discover_video_files(directory)
+
+    # Then: The bad file is counted as skipped and the good one still appears
+    assert report.total == 2
+    assert len(report.skipped) == 1
+    assert report.skipped[0].path.name == "bad.mkv"
+
+
+def test_discover_depth_zero_ignores_subdirectories(video_library):
+    """Verify the default depth does not descend into subdirectories."""
+    # Given: One top-level file and one nested a directory below
+    directory = video_library([("top.mkv", 100, 1_000_000), ("nested/deep.mkv", 100, 1_000_000)])
+
+    # When: Discovering at the default depth
+    report = discover_video_files(directory)
+
+    # Then: Only the top-level file is found
+    assert [r.video_file.path.name for r in report.results] == ["top.mkv"]
+
+
+def test_discover_depth_one_descends(video_library):
+    """Verify depth 1 finds files one directory below the root."""
+    # Given: One top-level file and one nested a directory below
+    directory = video_library([("top.mkv", 100, 1_000_000), ("nested/deep.mkv", 100, 1_000_000)])
+
+    # When: Discovering one level deep
+    report = discover_video_files(directory, depth=1)
+
+    # Then: Both files are found
+    assert {r.video_file.path.name for r in report.results} == {"top.mkv", "deep.mkv"}
+
+
+def test_discover_ties_break_alphabetically(video_library, mocker):
+    """Verify equal values on the active key fall back to path order, not scan order."""
+    # Given: Three identically sized files
+    directory = video_library(
+        [("alpha.mkv", 100, 0), ("bravo.mkv", 100, 0), ("charlie.mkv", 100, 0)]
+    )
+    # find_files' scan order is arbitrary; scramble it to prove the tiebreaker is real.
+    scrambled = [directory / "bravo.mkv", directory / "charlie.mkv", directory / "alpha.mkv"]
+    mocker.patch("vid_cleaner.controllers.discovery.find_files", return_value=scrambled)
+
+    # When: Sorting by a key that cannot break the tie
+    report = discover_video_files(directory, sort=SortOrder.SIZE)
+
+    # Then: Ties resolve alphabetically by path
+    assert [r.video_file.path.name for r in report.results] == [
+        "alpha.mkv",
+        "bravo.mkv",
+        "charlie.mkv",
+    ]

--- a/tests/controllers/test_temp_files.py
+++ b/tests/controllers/test_temp_files.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 from vid_cleaner import settings
 
-from vid_cleaner.controllers import TempFile  # isort: skip
+from vid_cleaner.controllers.temp_files import TempFile, cleanup_on_exit  # isort: skip
+from vid_cleaner.models.video_file import VideoFile  # isort: skip
 
 
 def test_temp_file_latest_temp_path(mock_video_path: Path, tmp_path: Path) -> None:
@@ -109,3 +110,44 @@ def test_temp_file_clean_up(mock_video_path: Path, tmp_path: Path) -> None:
     assert not output_path_2.exists()
     assert not output_path_3.exists()
     assert not output_path_3.parent.exists()
+
+
+def test_video_file_without_temps_registers_no_exit_hook(mocker, mock_video_path, tmp_path) -> None:
+    """Verify a probed-but-unprocessed file pins nothing for the life of the process.
+
+    A discovery run builds a VideoFile for every candidate it probes, so registering an
+    exit hook per instance would retain thousands of probe boxes to act on a handful.
+    """
+    # Given: A cache directory and a patched exit registry
+    settings.update({"cache_dir": Path(tmp_path)})
+    register = mocker.patch("vid_cleaner.controllers.temp_files.atexit.register")
+
+    # When: Building a VideoFile without ever creating a temporary file
+    VideoFile(mock_video_path)
+
+    # Then: Nothing was registered
+    register.assert_not_called()
+
+
+def test_temp_file_registers_exit_cleanup_once_a_temp_exists(
+    mocker, mock_video_path, tmp_path
+) -> None:
+    """Verify a file that creates a temp is still cleaned up when the interpreter exits."""
+    # Given: A cache directory and a patched exit registry
+    settings.update({"cache_dir": Path(tmp_path)})
+    register = mocker.patch("vid_cleaner.controllers.temp_files.atexit.register")
+    video_file = VideoFile(mock_video_path)
+
+    # When: Creating two temporary files
+    first = video_file.temp_file.new_tmp_path(step_name="clean")
+    first.touch()
+    video_file.temp_file.created_temp_file(first)
+    second = video_file.temp_file.new_tmp_path(step_name="clip")
+    second.touch()
+
+    # Then: A single hook was registered, and running it clears the temp directory
+    register.assert_called_once_with(cleanup_on_exit, video_file.temp_file)
+    cleanup_on_exit(video_file.temp_file)
+    assert not first.exists()
+    assert not second.exists()
+    assert not video_file.temp_file.tmp_dir.exists()

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -7,6 +7,7 @@ import cappa
 import pytest
 from iso639 import Lang
 
+from vid_cleaner.constants import TREE_LAST
 from vid_cleaner.exceptions import VideoCleanError
 from vid_cleaner.models import video_file as video_file_module
 from vid_cleaner.vidcleaner import VidCleaner, config_subcommand
@@ -1718,3 +1719,32 @@ def test_clean_from_declining_the_prompt_changes_nothing(
     mock_ffmpeg.assert_not_called()
     write.assert_not_called()
     assert video.read_bytes() == original
+
+
+def test_clean_renders_one_tree_per_file(
+    mocker, mock_ffprobe_box, mock_video_path, capsys, mock_ffmpeg
+):
+    """Verify a file's operations and outcomes close a single tree, not one each."""
+    # Given: A file whose operations render up front and whose write then reports a save
+    args = ["clean", "-vv", "--h265", str(mock_video_path)]
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("reference.json"),
+    )
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: Everything printed for the file closes a single tree, on its last line
+    assert exc_info.value.code == 0
+    per_file = output.rsplit("\u21e8", 1)[-1]
+    assert per_file.count(TREE_LAST) == 1
+    assert TREE_LAST in per_file.splitlines()[-1]

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1482,3 +1482,67 @@ def test_clean_from_empty_directory_still_exits_zero(capsys, tmp_path):
     # Then: The command reports the empty directory and exits successfully
     assert exc_info.value.code == 0
     assert "No video files found" in capsys.readouterr().err
+
+
+def test_clean_removes_the_original_even_when_temp_cleanup_fails(
+    mocker, mock_ffprobe_box, mock_ffmpeg, capsys, tmp_path
+):
+    """Verify a failed temp cleanup does not skip removing the original under --overwrite."""
+    # Given: --overwrite writing to a new path, and temp housekeeping that raises
+    source = tmp_path / "movie.mkv"
+    source.touch()
+    destination = tmp_path / "out.mkv"
+    args = ["clean", "-vv", "--overwrite", "--out", str(destination), str(source)]
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("reference.json"),
+    )
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, [f"✔ Saved to {dst}"]),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+    mocker.patch.object(TempFile, "clean_up", side_effect=OSError("temp dir busy"))
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The original is gone and the cleanup failure is reported as its own warning
+    assert exc_info.value.code == 0
+    assert not source.exists()
+    assert "temp dir busy" in output
+
+
+def test_clean_reports_a_failed_original_removal_accurately(
+    mocker, mock_ffprobe_box, mock_ffmpeg, capsys, tmp_path
+):
+    """Verify a failed removal of the original is not reported as a temp-file cleanup error."""
+    # Given: --overwrite writing to a new path, where removing the original raises
+    source = tmp_path / "movie.mkv"
+    source.touch()
+    destination = tmp_path / "out.mkv"
+    args = ["clean", "-vv", "--overwrite", "--out", str(destination), str(source)]
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("reference.json"),
+    )
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, [f"✔ Saved to {dst}"]),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+    mocker.patch.object(Path, "unlink", side_effect=OSError("read-only file system"))
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The warning names the original file, not the temporary files
+    assert exc_info.value.code == 0
+    assert "could not remove the original" in output
+    assert "could not clean up temporary files" not in output

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -8,6 +8,7 @@ import pytest
 from iso639 import Lang
 
 from vid_cleaner.exceptions import VideoCleanError
+from vid_cleaner.models import video_file as video_file_module
 from vid_cleaner.vidcleaner import VidCleaner, config_subcommand
 
 from vid_cleaner.models.video_file import VideoFile  # isort: skip
@@ -1546,3 +1547,174 @@ def test_clean_reports_a_failed_original_removal_accurately(
     assert exc_info.value.code == 0
     assert "could not remove the original" in output
     assert "could not clean up temporary files" not in output
+
+
+def _normalize(text: str) -> str:
+    """Collapse Rich's line wrapping so assertions can match whole phrases.
+
+    Returns:
+        str: The text with every run of whitespace reduced to a single space.
+    """
+    return " ".join(text.split())
+
+
+def test_clean_failure_lines_name_the_file_exactly_once(capsys, tmp_path, mocker, mock_ffmpeg):
+    """Verify a domain error's failure line carries the short reason, not the full message.
+
+    `VideoCleanError` embeds the absolute path in its own message, so reporting `str(e)`
+    under a line already prefixed with the filename names the file twice.
+    """
+    # Given: One file failing with a domain error and one with a plain RuntimeError
+    first = tmp_path / "first.mkv"
+    first.touch()
+    second = tmp_path / "second.mkv"
+    second.touch()
+
+    def clean(self):
+        if self.path.name == "first.mkv":
+            raise VideoCleanError(path=self.path, reason="no video streams found")
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    mocker.patch("vid_cleaner.models.video_file.VideoFile.clean", clean)
+
+    # When: Cleaning both files
+    args = ["-n", "clean", str(first), str(second)]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output, error = capsys.readouterr()
+    combined = _normalize(output + error)
+
+    # Then: The domain failure names the file once, and the plain error still names it
+    assert exc_info.value.code == 1
+    assert "first.mkv: no video streams found" in combined
+    assert "Could not clean" not in combined
+    assert "second.mkv: boom" in combined
+
+
+def test_clean_clears_the_temp_directory_when_a_file_fails(capsys, tmp_path, mocker, mock_ffmpeg):
+    """Verify a failed file's full-size temp transcode is discarded immediately.
+
+    A batch that fails on every file would otherwise hold one full-size intermediate per
+    file on disk until the process exits.
+    """
+    # Given: A file that fails to clean
+    video = tmp_path / "movie.mkv"
+    video.touch()
+
+    def clean(self):
+        raise VideoCleanError(path=self.path, reason="no video streams found")
+
+    mocker.patch("vid_cleaner.models.video_file.VideoFile.clean", clean)
+    cleanup = mocker.patch.object(TempFile, "clean_up")
+
+    # When: Cleaning it
+    args = ["-n", "clean", str(video)]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The temp directory was cleared as part of handling the failure
+    assert exc_info.value.code == 1
+    cleanup.assert_called_once()
+
+
+def test_clean_from_cleanup_failure_does_not_mask_the_real_failure(
+    capsys, tmp_path, mocker, mock_ffmpeg
+):
+    """Verify a cleanup error while handling a failure does not replace the reported cause."""
+    # Given: A file that fails to clean and whose temp cleanup then also fails
+    video = tmp_path / "movie.mkv"
+    video.touch()
+
+    def clean(self):
+        raise VideoCleanError(path=self.path, reason="no video streams found")
+
+    mocker.patch("vid_cleaner.models.video_file.VideoFile.clean", clean)
+    mocker.patch.object(TempFile, "clean_up", side_effect=OSError("temp dir busy"))
+
+    # When: Cleaning it
+    args = ["-n", "clean", str(video)]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output, error = capsys.readouterr()
+    combined = _normalize(output + error)
+
+    # Then: The original cause is still what the batch reports
+    assert exc_info.value.code == 1
+    assert "movie.mkv: no video streams found" in combined
+
+
+def test_clean_from_yes_reaches_the_transcode_loop(capsys, video_library, mocker, mock_ffmpeg):
+    """Verify --yes skips the prompt and actually transcodes the discovered selection."""
+    # Given: Two discoverable files and a stubbed writer
+    directory = video_library([("apple.mkv", 100, 1_000_000), ("banana.mkv", 200, 1_000_000)])
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, [f"✔ Saved to {dst}"]),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+    args = ["clean", "--from", str(directory), "--filters", "h264", "--yes"]
+
+    # When: Running clean with --yes and no TTY
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: Both files were transcoded and written
+    assert exc_info.value.code == 0
+    assert mock_ffmpeg.call_count == 2
+    assert "apple.mkv" in output
+    assert "banana.mkv" in output
+
+
+def test_clean_from_yes_reuses_the_discovery_probe(capsys, video_library, mocker, mock_ffmpeg):
+    """Verify each file is probed once, not again when the transcode loop reaches it.
+
+    Discovery already probed every candidate and `VideoFile` caches the result, so
+    `select_video_files` hands back those instances. Rebuilding them from paths would
+    silently double the dominant cost of a large `--from` run.
+    """
+    # Given: Two discoverable files and a stubbed writer
+    directory = video_library([("apple.mkv", 100, 1_000_000), ("banana.mkv", 200, 1_000_000)])
+    probe = video_file_module.get_probe_as_box
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, [f"✔ Saved to {dst}"]),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+    args = ["clean", "--from", str(directory), "--filters", "h264", "--yes"]
+
+    # When: Running clean with --yes
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: ffprobe ran exactly once per file
+    assert exc_info.value.code == 0
+    assert probe.call_count == 2
+
+
+def test_clean_from_declining_the_prompt_changes_nothing(
+    capsys, video_library, mocker, mock_ffmpeg, interactive_console
+):
+    """Verify answering no is a successful no-op that leaves every file untouched."""
+    # Given: A discoverable file and a user who declines the prompt
+    directory = video_library([("apple.mkv", 100, 1_000_000)])
+    video = directory / "apple.mkv"
+    original = video.read_bytes()
+    interactive_console(is_terminal=True)
+    mocker.patch("vid_cleaner.cli.discovery_output.Confirm.ask", return_value=False)
+    write = mocker.patch("vid_cleaner.cli.clean_video.copy_to_output")
+    args = ["clean", "--from", str(directory), "--filters", "h264"]
+
+    # When: Running clean and declining
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: Nothing was transcoded, nothing was written, and the file is unchanged
+    assert exc_info.value.code == 0
+    mock_ffmpeg.assert_not_called()
+    write.assert_not_called()
+    assert video.read_bytes() == original

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1405,3 +1405,80 @@ def test_clean_write_output_cleanup_failure_still_reports_the_save(
     assert "cleaned_video.mkv" in output
     assert "temp dir busy" in output
     assert "failed" not in output
+
+
+def test_clean_rejects_yes_without_from(capsys, tmp_path):
+    """Verify --yes without --from errors rather than being accepted as a no-op."""
+    # Given: --yes on an explicit-file run, where no prompt would ever be shown
+    video = tmp_path / "movie.mkv"
+    video.touch()
+    args = ["clean", "--yes", str(video)]
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command errors naming --from
+    assert exc_info.value.code == 1
+    assert "require `--from`" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("limit", ["0", "-1"])
+def test_clean_rejects_limit_below_one(capsys, tmp_path, limit):
+    """Verify a limit below one is refused instead of silently selecting the wrong files."""
+    # Given: A discovery run asking for a zero or negative limit
+    args = ["clean", "--from", str(tmp_path), "--limit", limit]
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command fails with a message naming the acceptable range
+    assert exc_info.value.code != 0
+    assert "must be 1 or greater" in str(exc_info.value.message)
+
+
+def test_clean_rejects_from_that_does_not_exist(capsys, tmp_path):
+    """Verify a missing --from directory fails instead of reporting a successful no-op."""
+    # Given: A --from path that does not exist
+    args = ["clean", "--from", str(tmp_path / "does-not-exist")]
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command errors rather than exiting 0
+    assert exc_info.value.code == 1
+    assert "`--from` must be an existing directory" in capsys.readouterr().err
+
+
+def test_clean_rejects_from_that_is_a_file(capsys, tmp_path):
+    """Verify a --from pointing at a file fails, since clean otherwise takes file paths."""
+    # Given: A --from path naming a file rather than a directory
+    video = tmp_path / "movie.mkv"
+    video.touch()
+    args = ["clean", "--from", str(video)]
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command errors rather than exiting 0
+    assert exc_info.value.code == 1
+    assert "`--from` must be an existing directory" in capsys.readouterr().err
+
+
+def test_clean_from_empty_directory_still_exits_zero(capsys, tmp_path):
+    """Verify a real but empty directory remains a successful no-op, not a failure."""
+    # Given: An existing directory holding no video files
+    directory = tmp_path / "library"
+    directory.mkdir()
+    args = ["clean", "--from", str(directory)]
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command reports the empty directory and exits successfully
+    assert exc_info.value.code == 0
+    assert "No video files found" in capsys.readouterr().err

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1490,11 +1490,11 @@ def test_clean_removes_the_original_even_when_temp_cleanup_fails(
     mocker, mock_ffprobe_box, mock_ffmpeg, capsys, tmp_path
 ):
     """Verify a failed temp cleanup does not skip removing the original under --overwrite."""
-    # Given: --overwrite writing to a new path, and temp housekeeping that raises
+    # Given: --overwrite renaming the result to a new container, and temp housekeeping
+    # that raises
     source = tmp_path / "movie.mkv"
     source.touch()
-    destination = tmp_path / "out.mkv"
-    args = ["clean", "-vv", "--overwrite", "--out", str(destination), str(source)]
+    args = ["clean", "-vv", "--overwrite", "--vp9", str(source)]
     mocker.patch(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
@@ -1522,11 +1522,11 @@ def test_clean_reports_a_failed_original_removal_accurately(
     mocker, mock_ffprobe_box, mock_ffmpeg, capsys, tmp_path
 ):
     """Verify a failed removal of the original is not reported as a temp-file cleanup error."""
-    # Given: --overwrite writing to a new path, where removing the original raises
+    # Given: --overwrite renaming the result to a new container, where removing the
+    # original raises
     source = tmp_path / "movie.mkv"
     source.touch()
-    destination = tmp_path / "out.mkv"
-    args = ["clean", "-vv", "--overwrite", "--out", str(destination), str(source)]
+    args = ["clean", "-vv", "--overwrite", "--vp9", str(source)]
     mocker.patch(
         "vid_cleaner.models.video_file.get_probe_as_box",
         return_value=mock_ffprobe_box("reference.json"),
@@ -1548,6 +1548,39 @@ def test_clean_reports_a_failed_original_removal_accurately(
     assert exc_info.value.code == 0
     assert "could not remove the original" in output
     assert "could not clean up temporary files" not in output
+
+
+def test_clean_out_with_overwrite_leaves_the_input_alone(
+    mocker, mock_ffprobe_box, mock_ffmpeg, tmp_path
+):
+    """Verify `--out` never deletes the input, even when `--overwrite` is also passed.
+
+    `--overwrite` only says "do not keep a backup of what I am replacing". With `--out`
+    the input is not being replaced, so removing it would destroy a file the user asked
+    to read from, not write to.
+    """
+    # Given: --overwrite writing the result to a destination the user chose
+    source = tmp_path / "movie.mkv"
+    source.touch()
+    destination = tmp_path / "out.mkv"
+    args = ["clean", "--overwrite", "--out", str(destination), str(source)]
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("reference.json"),
+    )
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, [f"✔ Saved to {dst}"]),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The input file is still there
+    assert exc_info.value.code == 0
+    assert source.exists()
 
 
 def _normalize(text: str) -> str:

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1748,3 +1748,76 @@ def test_clean_renders_one_tree_per_file(
     per_file = output.rsplit("\u21e8", 1)[-1]
     assert per_file.count(TREE_LAST) == 1
     assert TREE_LAST in per_file.splitlines()[-1]
+
+
+@pytest.fixture
+def fake_transcode(mocker):
+    """Replace the ffmpeg pass with one that writes a real temporary file.
+
+    Lets a test exercise the genuine `copy_to_output` write, and so the output path and
+    the fate of the original, rather than stubbing the write out.
+
+    Returns:
+        Callable[[], None]: Call to install the replacement.
+    """
+
+    def _inner() -> None:
+        def run_ffmpeg(self, command, title, suffix=None, step=None):
+            output_path = self.temp_file.new_tmp_path(suffix=suffix or "", step_name=step or "")
+            output_path.write_bytes(b"transcoded")
+            self.temp_file.created_temp_file(output_path)
+            return [f"✔ {title}"]
+
+        mocker.patch.object(VideoFile, "_run_ffmpeg", run_ffmpeg)
+
+    return _inner
+
+
+def test_clean_vp9_writes_a_webm_file(mocker, mock_ffprobe_box, capsys, tmp_path, fake_transcode):
+    """Verify --vp9 names the output for the container it actually produced."""
+    # Given: An .mkv input converted to VP9
+    video = tmp_path / "movie.mkv"
+    video.touch()
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("reference.json"),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+    fake_transcode()
+
+    # When: Cleaning it to VP9 without --overwrite
+    args = ["clean", "--vp9", str(video)]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: WebM data lands in a .webm file, the original is untouched, and no pointless
+    # backup of a file that was never overwritten is left behind
+    assert exc_info.value.code == 0
+    assert (tmp_path / "movie.webm").read_bytes() == b"transcoded"
+    assert video.exists()
+    assert not list(tmp_path.glob("*.bak"))
+
+
+def test_clean_vp9_overwrite_removes_the_original_container(
+    mocker, mock_ffprobe_box, capsys, tmp_path, fake_transcode
+):
+    """Verify --overwrite removes the source .mkv once the result lands in a .webm."""
+    # Given: An .mkv input converted to VP9 with --overwrite
+    video = tmp_path / "movie.mkv"
+    video.touch()
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("reference.json"),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+    fake_transcode()
+
+    # When: Cleaning it to VP9 in place
+    args = ["clean", "--vp9", "--overwrite", str(video)]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: Only the .webm remains, so the container change does not leave two copies
+    assert exc_info.value.code == 0
+    assert (tmp_path / "movie.webm").read_bytes() == b"transcoded"
+    assert not video.exists()

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -7,6 +7,7 @@ import cappa
 import pytest
 from iso639 import Lang
 
+from vid_cleaner.exceptions import VideoCleanError
 from vid_cleaner.vidcleaner import VidCleaner, config_subcommand
 
 from vid_cleaner.models.video_file import VideoFile  # isort: skip
@@ -796,7 +797,12 @@ def test_clean_multiple_files_overwrite_each_in_place(
 def test_clean_renders_completed_steps_on_error(
     mocker, mock_ffprobe_box, mock_ffmpeg, capsys, mock_video_path
 ) -> None:
-    """Verify operations render up front even when the later write step raises."""
+    """Verify operations render up front even when the later write step raises.
+
+    A write failure is a per-file failure like any other: it is reported and the batch
+    exits non-zero rather than propagating raw, since a single write error must not be
+    able to look different from any other file-level failure to the caller.
+    """
     # Given: operations render up front inside clean(), before the write step, so a
     # failing write can't hide what already completed
     args = ["clean", "-vv", "--h265", str(mock_video_path)]
@@ -811,16 +817,19 @@ def test_clean_renders_completed_steps_on_error(
     )
 
     # When: running clean and the output write raises after processing completes
-    with pytest.raises(RuntimeError):
+    with pytest.raises(cappa.Exit) as exc_info:
         cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
 
     # Then: the operations render up front, before the failing write, proving the CLI
     # reports what actually happened even when `write_output()` raises. reference.json's
     # video stream is already first, so reorder is skipped and H.265 conversion is the
-    # operation that proves clean() ran to completion.
-    output = capsys.readouterr().out
+    # operation that proves clean() ran to completion. The write failure is reported and
+    # the command exits non-zero rather than crashing.
+    output, error = capsys.readouterr()
+    assert exc_info.value.code == 1
     assert "✔ Convert to H.265" in output
     assert "✖ Reorder streams  (streams already in order)" in output
+    assert "1 file(s) failed" in output + error
 
 
 def test_clean_video_downmix_skip_when_stereo_exists(
@@ -1284,3 +1293,75 @@ def test_clean_from_limit_selects_top_results(capsys, video_library, mock_ffmpeg
     assert exc_info.value.code == 0
     assert "banana.mkv" in output
     assert "apple.mkv" not in output
+
+
+def test_clean_continues_after_a_file_fails(capsys, tmp_path, mocker, mock_ffmpeg):
+    """Verify one failing file does not discard the work queued behind it."""
+    # Given: Two files where the first fails to clean
+    first = tmp_path / "first.mkv"
+    first.touch()
+    second = tmp_path / "second.mkv"
+    second.touch()
+
+    def clean(self):
+        if self.path.name == "first.mkv":
+            msg = "no video streams found"
+            raise VideoCleanError(path=self.path, reason=msg)
+        return []
+
+    mocker.patch("vid_cleaner.models.video_file.VideoFile.clean", clean)
+
+    # When: Cleaning both files
+    args = ["-n", "clean", str(first), str(second)]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output, error = capsys.readouterr()
+
+    # Then: The second file was still attempted and the failure is reported at the end
+    assert exc_info.value.code == 1
+    assert "second.mkv" in output
+    assert "first.mkv" in output + error
+    assert "1 file(s) failed" in output + error
+
+
+def test_clean_exits_zero_when_every_file_succeeds(capsys, tmp_path, mocker, mock_ffmpeg):
+    """Verify a clean run with no failures still exits successfully."""
+    # Given: One file that cleans without error
+    video = tmp_path / "movie.mkv"
+    video.touch()
+    mocker.patch("vid_cleaner.models.video_file.VideoFile.clean", return_value=[])
+
+    # When: Cleaning it
+    args = ["-n", "clean", str(video)]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command exits successfully with no failure report
+    assert exc_info.value.code == 0
+    assert "failed" not in capsys.readouterr().out
+
+
+def test_clean_keyboard_interrupt_aborts_the_whole_batch(capsys, tmp_path, mocker):
+    """Verify Ctrl-C stops the run rather than being collected as a per-file failure."""
+    # Given: Two files where the first raises the exit cappa uses for an interrupt
+    first = tmp_path / "first.mkv"
+    first.touch()
+    second = tmp_path / "second.mkv"
+    second.touch()
+
+    def clean(self):
+        if self.path.name == "first.mkv":
+            raise cappa.Exit(code=1)
+        return []
+
+    mocker.patch("vid_cleaner.models.video_file.VideoFile.clean", clean)
+
+    # When: Cleaning both files
+    args = ["-n", "clean", str(first), str(second)]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The run aborts before reaching the second file
+    assert exc_info.value.code == 1
+    assert "second.mkv" not in capsys.readouterr().out

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1365,3 +1365,43 @@ def test_clean_keyboard_interrupt_aborts_the_whole_batch(capsys, tmp_path, mocke
     # Then: The run aborts before reaching the second file
     assert exc_info.value.code == 1
     assert "second.mkv" not in capsys.readouterr().out
+
+
+def test_clean_write_output_cleanup_failure_still_reports_the_save(
+    mocker,
+    mock_ffprobe_box,
+    mock_video_path,
+    capsys,
+    mock_ffmpeg,
+):
+    """Verify a cleanup error after a successful write is a warning, not a per-file failure.
+
+    The file is already copied to its destination by the time `TempFile.clean_up()` runs,
+    so a failure there must not discard the "Saved to" message or count the file as failed.
+    """
+    # Given: a file that cleans and writes successfully, but whose temp-directory
+    # housekeeping raises after the output is already safely in place
+    args = ["clean", "-vv", str(mock_video_path)]
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("reference.json"),
+    )
+    mocker.patch.object(VideoFile, "_find_original_language", return_value=Lang("en"))
+    mocker.patch(
+        "vid_cleaner.cli.clean_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to cleaned_video.mkv"]),
+    )
+    mocker.patch.object(TempFile, "clean_up", side_effect=OSError("temp dir busy"))
+
+    # When: running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: the run still exits successfully, the save is still reported, and the
+    # cleanup failure is surfaced as a warning rather than a batch failure
+    assert exc_info.value.code == 0
+    assert "cleaned_video.mkv" in output
+    assert "temp dir busy" in output
+    assert "failed" not in output

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1160,3 +1160,127 @@ def test_query_arr_apps_for_imdb_id_radarr(mocker, tmp_path, radarr_response, ex
 
     # Then: the IMDb ID is returned when present, otherwise None
     assert result == expected
+
+
+def test_clean_rejects_from_with_positional_files(capsys, tmp_path):
+    """Verify --from and explicit files are refused together as conflicting sources."""
+    # Given: Both a discovery root and an explicit file
+    video = tmp_path / "movie.mkv"
+    video.touch()
+    args = ["clean", "--from", str(tmp_path), str(video)]
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command errors explaining the conflict
+    assert exc_info.value.code == 1
+    assert "`--from` cannot be combined with explicit file paths" in capsys.readouterr().err
+
+
+def test_clean_rejects_from_with_out(capsys, tmp_path):
+    """Verify --out is refused with --from, since one path cannot name a multi-file selection."""
+    # Given: A discovery root and an explicit output path
+    args = ["clean", "--from", str(tmp_path), "--out", str(tmp_path / "out.mkv")]
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command errors
+    assert exc_info.value.code == 1
+    assert "`--out` cannot be used with `--from`" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "discovery_arg",
+    [["--filters", "h264"], ["--limit", "2"], ["--depth", "1"], ["--reverse"], ["--sort", "size"]],
+)
+def test_clean_rejects_discovery_flags_without_from(capsys, tmp_path, discovery_arg):
+    """Verify a discovery flag without --from errors rather than silently doing nothing."""
+    # Given: A discovery flag on an explicit-file run
+    video = tmp_path / "movie.mkv"
+    video.touch()
+    args = ["clean", str(video), *discovery_arg]
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command errors naming --from
+    assert exc_info.value.code == 1
+    assert "require `--from`" in capsys.readouterr().err
+
+
+def test_clean_rejects_no_files_and_no_from(capsys):
+    """Verify clean with neither a file nor --from is a usage error."""
+    # Given: No files and no discovery root
+    args = ["clean"]
+
+    # When: Running clean
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    # Then: The command errors
+    assert exc_info.value.code == 1
+    assert "Provide file path(s) or `--from`" in capsys.readouterr().err
+
+
+def test_clean_from_previews_and_requires_confirmation(capsys, video_library):
+    """Verify discovery mode renders the selection table and refuses to run non-interactively."""
+    # Given: Two discoverable files
+    directory = video_library([("apple.mkv", 100, 1_000_000), ("banana.mkv", 200, 1_000_000)])
+    args = ["clean", "--from", str(directory), "--filters", "h264"]
+
+    # When: Running clean with no TTY and no --yes
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output, error = capsys.readouterr()
+
+    # Then: The table rendered before the refusal, so the user still sees the selection
+    assert exc_info.value.code == 1
+    assert "apple.mkv" in output
+    assert "--yes" in error
+
+
+def test_clean_from_dryrun_skips_the_prompt(capsys, video_library, mock_ffmpeg):
+    """Verify --dryrun previews without prompting, since a preview is not an action."""
+    # Given: Two discoverable files
+    directory = video_library([("apple.mkv", 100, 1_000_000), ("banana.mkv", 200, 1_000_000)])
+    args = ["-n", "clean", "--from", str(directory), "--filters", "h264"]
+
+    # When: Running a dry run with no TTY and no --yes
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output, error = capsys.readouterr()
+
+    # Then: It completes successfully without demanding --yes
+    assert exc_info.value.code == 0
+    assert "apple.mkv" in output
+    assert "--yes" not in error
+
+
+def test_clean_from_limit_selects_top_results(capsys, video_library, mock_ffmpeg):
+    """Verify --limit narrows what discovery mode acts on."""
+    # Given: Three discoverable files
+    directory = video_library(
+        [
+            ("apple.mkv", 100, 1_000_000),
+            ("banana.mkv", 300, 1_000_000),
+            ("cherry.mkv", 200, 1_000_000),
+        ]
+    )
+    args = ["-n", "clean", "--from", str(directory), "--sort", "size", "--limit", "1"]
+
+    # When: Previewing the single largest file
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: Only the largest file is selected
+    assert exc_info.value.code == 0
+    assert "banana.mkv" in output
+    assert "apple.mkv" not in output

--- a/tests/test_clean_planning.py
+++ b/tests/test_clean_planning.py
@@ -3,12 +3,12 @@
 
 from pathlib import Path
 
-import cappa
 import pytest
 from iso639 import Lang
 
 from vid_cleaner import settings
 from vid_cleaner.constants import CodecTypes
+from vid_cleaner.exceptions import VideoCleanError
 
 from vid_cleaner.models.video_file import VideoFile  # isort: skip
 
@@ -361,10 +361,12 @@ def test_clean_no_video_streams_raises(make_video):
     video = make_video("audio_only.json")
 
     # When: cleaning
-    # Then: cappa.Exit is raised with code 1
-    with pytest.raises(cappa.Exit) as exc_info:
+    # Then: VideoCleanError is raised, distinct from cappa.Exit, so a batch loop can
+    # catch it and continue to the next file without swallowing a real interrupt
+    with pytest.raises(VideoCleanError) as exc_info:
         video.clean()
-    assert exc_info.value.code == 1
+    assert exc_info.value.path == video.path
+    assert exc_info.value.reason == "no video streams found"
 
 
 def test_clean_no_audio_streams_raises(make_video):
@@ -373,10 +375,12 @@ def test_clean_no_audio_streams_raises(make_video):
     video = make_video("video_only.json")
 
     # When: cleaning
-    # Then: cappa.Exit is raised with code 1
-    with pytest.raises(cappa.Exit) as exc_info:
+    # Then: VideoCleanError is raised, distinct from cappa.Exit, so a batch loop can
+    # catch it and continue to the next file without swallowing a real interrupt
+    with pytest.raises(VideoCleanError) as exc_info:
         video.clean()
-    assert exc_info.value.code == 1
+    assert exc_info.value.path == video.path
+    assert exc_info.value.reason == "no audio streams found"
 
 
 def test_clean_noop_skips_ffmpeg(make_video, mock_ffmpeg):

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -6,6 +6,7 @@ import cappa
 import pytest
 
 from vid_cleaner import settings
+from vid_cleaner.controllers import TempFile
 from vid_cleaner.vidcleaner import VidCleaner, config_subcommand
 
 
@@ -132,3 +133,36 @@ def test_clipping_video_dryrun(
     assert exc_info.value.code == 0
     assert "dry run" in output
     assert "clipped_video.mkv" not in output
+
+
+def test_clip_cleanup_failure_still_reports_the_save(
+    mocker, mock_ffprobe_box, mock_video_path, capsys, mock_ffmpeg, tmp_path
+):
+    """Verify a cleanup error after a successful clip is a warning, not a crash.
+
+    The clip is already copied to its destination by the time `TempFile.clean_up()` runs,
+    so a failure there must not discard the "Saved to" message or propagate out of main().
+    """
+    # Given: a clip that writes successfully but whose temp-directory housekeeping raises
+    args = ["clip", str(mock_video_path)]
+    settings.update({"cache_dir": Path(tmp_path), "langs_to_keep": ["en"]})
+    mocker.patch(
+        "vid_cleaner.models.video_file.get_probe_as_box",
+        return_value=mock_ffprobe_box("reference.json"),
+    )
+    mocker.patch(
+        "vid_cleaner.cli.clip_video.copy_to_output",
+        side_effect=lambda src, dst, *, overwrite: (dst, ["✔ Saved to clipped_video.mkv"]),
+    )
+    mocker.patch.object(TempFile, "clean_up", side_effect=OSError("temp dir busy"))
+
+    # When: Running clip
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The save survives, the cleanup failure is a warning, and the run still succeeds
+    assert exc_info.value.code == 0
+    assert "clipped_video.mkv" in output
+    assert "temp dir busy" in output

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -59,3 +59,15 @@ def test_no_applied_actions_shows_no_changes(capsys):
     ]
     render_operations(actions, debug=False)
     assert "No changes needed" in _plain(capsys)
+
+
+def test_open_tree_branches_every_line(capsys):
+    """Verify an unclosed tree never emits TREE_LAST, so later lines extend the same tree."""
+    actions = [
+        PlanAction(label="Reorder streams", applied=True),
+        PlanAction(label="Convert to H.265", applied=True),
+    ]
+    render_operations(actions, debug=True, closes_tree=False)
+    out = _plain(capsys)
+    assert TREE_BRANCH in out
+    assert TREE_LAST not in out

--- a/tests/test_discovery_output.py
+++ b/tests/test_discovery_output.py
@@ -117,28 +117,6 @@ def test_confirm_returns_when_assume_yes(mocker, capsys):
     ask.assert_not_called()
 
 
-@pytest.fixture
-def interactive_console(mocker):
-    """Force `Console.is_terminal` so the prompt path can be exercised under pytest.
-
-    Patch the property on the class rather than replacing `pp.console`, which would hand
-    `pp.error` a mock and silently break stderr capture in these same tests.
-
-    Returns:
-        Callable[..., None]: Call with `is_terminal=True` or `is_terminal=False` to set
-            interactivity.
-    """
-
-    def _inner(*, is_terminal: bool) -> None:
-        mocker.patch(
-            "rich.console.Console.is_terminal",
-            new_callable=mocker.PropertyMock,
-            return_value=is_terminal,
-        )
-
-    return _inner
-
-
 def test_confirm_errors_on_non_tty_without_yes(mocker, capsys, interactive_console):
     """Verify a non-interactive terminal without --yes errors instead of hanging on stdin."""
     # Given: A non-interactive console

--- a/tests/test_discovery_output.py
+++ b/tests/test_discovery_output.py
@@ -124,10 +124,11 @@ def interactive_console(mocker):
     `pp.error` a mock and silently break stderr capture in these same tests.
 
     Returns:
-        Callable[[bool], None]: Call with True or False to set interactivity.
+        Callable[..., None]: Call with `is_terminal=True` or `is_terminal=False` to set
+            interactivity.
     """
 
-    def _inner(is_terminal: bool) -> None:  # noqa: FBT001
+    def _inner(*, is_terminal: bool) -> None:
         mocker.patch(
             "rich.console.Console.is_terminal",
             new_callable=mocker.PropertyMock,
@@ -141,7 +142,7 @@ def test_confirm_errors_on_non_tty_without_yes(mocker, capsys, interactive_conso
     """Verify a non-interactive terminal without --yes errors instead of hanging on stdin."""
     # Given: A non-interactive console
     report = make_report(results=[make_result(mocker, "a.mkv", 100)], total=1)
-    interactive_console(False)  # noqa: FBT003
+    interactive_console(is_terminal=False)
 
     # When: Confirming without assume_yes
     with pytest.raises(cappa.Exit) as exc_info:
@@ -156,7 +157,7 @@ def test_confirm_exits_zero_when_declined(mocker, interactive_console):
     """Verify declining is a successful no-op, not a failure."""
     # Given: An interactive console where the user answers no
     report = make_report(results=[make_result(mocker, "a.mkv", 100)], total=1)
-    interactive_console(True)  # noqa: FBT003
+    interactive_console(is_terminal=True)
     mocker.patch("vid_cleaner.cli.discovery_output.Confirm.ask", return_value=False)
 
     # When: Confirming
@@ -171,7 +172,7 @@ def test_confirm_returns_when_accepted(mocker, interactive_console):
     """Verify accepting prompts once and lets the caller proceed."""
     # Given: An interactive console where the user answers yes
     report = make_report(results=[make_result(mocker, "a.mkv", 100)], total=1)
-    interactive_console(True)  # noqa: FBT003
+    interactive_console(is_terminal=True)
     ask = mocker.patch("vid_cleaner.cli.discovery_output.Confirm.ask", return_value=True)
 
     # When: Confirming
@@ -188,7 +189,7 @@ def test_confirm_prompt_reports_count_and_total_size(mocker, interactive_console
         results=[make_result(mocker, "a.mkv", 100), make_result(mocker, "b.mkv", 200)],
         total=2,
     )
-    interactive_console(True)  # noqa: FBT003
+    interactive_console(is_terminal=True)
     ask = mocker.patch("vid_cleaner.cli.discovery_output.Confirm.ask", return_value=True)
 
     # When: Confirming

--- a/tests/test_discovery_output.py
+++ b/tests/test_discovery_output.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import cappa
 import pytest
 
+from vid_cleaner import settings
 from vid_cleaner.cli.discovery_output import confirm_selection, present_discovery
 from vid_cleaner.constants import SortOrder, VideoTrait
 from vid_cleaner.controllers.discovery import DiscoveryReport
@@ -199,3 +200,56 @@ def test_confirm_prompt_reports_count_and_total_size(mocker, interactive_console
     prompt = ask.call_args.args[0]
     assert "2 files" in prompt
     assert "300" in prompt
+
+
+@pytest.fixture
+def overwrite_setting():
+    """Set `settings.overwrite` for one test and restore it afterwards.
+
+    Returns:
+        Callable[..., None]: Call with `overwrite=True` or `overwrite=False`.
+    """
+    original = settings.overwrite
+
+    def _inner(*, overwrite: bool) -> None:
+        settings.update({"overwrite": overwrite})
+
+    yield _inner
+    settings.update({"overwrite": original})
+
+
+def test_confirm_prompt_promises_a_backup_by_default(
+    mocker, interactive_console, overwrite_setting
+):
+    """Verify the default prompt says each original is backed up before it is rewritten."""
+    # Given: A selection cleaned without --overwrite
+    report = make_report(results=[make_result(mocker, "a.mkv", 100)], total=1)
+    overwrite_setting(overwrite=False)
+    interactive_console(is_terminal=True)
+    ask = mocker.patch("vid_cleaner.cli.discovery_output.Confirm.ask", return_value=True)
+
+    # When: Confirming
+    confirm_selection(report, assume_yes=False)
+
+    # Then: The prompt promises a backup
+    prompt = ask.call_args.args[0]
+    assert "backup" in prompt
+    assert "no backup" not in prompt
+
+
+def test_confirm_prompt_warns_when_overwriting_without_backup(
+    mocker, interactive_console, overwrite_setting
+):
+    """Verify --overwrite is disclosed, since it leaves nothing to restore the library from."""
+    # Given: A selection cleaned with --overwrite
+    report = make_report(results=[make_result(mocker, "a.mkv", 100)], total=1)
+    overwrite_setting(overwrite=True)
+    interactive_console(is_terminal=True)
+    ask = mocker.patch("vid_cleaner.cli.discovery_output.Confirm.ask", return_value=True)
+
+    # When: Confirming
+    confirm_selection(report, assume_yes=False)
+
+    # Then: The prompt says the originals are rewritten with no backup
+    prompt = ask.call_args.args[0]
+    assert "in place with no backup" in prompt

--- a/tests/test_discovery_output.py
+++ b/tests/test_discovery_output.py
@@ -26,7 +26,8 @@ def make_report(**overrides) -> DiscoveryReport:
         "truncated": 0,
         "sort": SortOrder.ALPHA,
         "descending": False,
-        "filtered": False,
+        "filters": set(),
+        "depth": 0,
     }
     return DiscoveryReport(**{**defaults, **overrides})
 
@@ -38,7 +39,7 @@ def test_present_exits_zero_when_nothing_found(capsys, tmp_path):
 
     # When: Presenting it
     with pytest.raises(cappa.Exit) as exc_info:
-        present_discovery(report, root=tmp_path, filters=set(), recursive=False)
+        present_discovery(report, root=tmp_path)
 
     # Then: The command warns and exits successfully
     assert exc_info.value.code == 0
@@ -48,11 +49,11 @@ def test_present_exits_zero_when_nothing_found(capsys, tmp_path):
 def test_present_exits_one_when_nothing_matched(capsys, tmp_path):
     """Verify files found but none matching the filters is an error naming the filters."""
     # Given: A report where candidates existed but none matched
-    report = make_report(total=3, filtered=True)
+    report = make_report(total=3, filters={VideoTrait.REORDER})
 
     # When: Presenting it with an active filter
     with pytest.raises(cappa.Exit) as exc_info:
-        present_discovery(report, root=tmp_path, filters={VideoTrait.REORDER}, recursive=False)
+        present_discovery(report, root=tmp_path)
 
     # Then: The command errors and names the unmatched filter
     assert exc_info.value.code == 1
@@ -64,13 +65,13 @@ def test_present_empty_match_reports_skipped_count(capsys, tmp_path):
     # Given: A report where every candidate was unreadable
     report = make_report(
         total=1,
-        filtered=True,
+        filters={VideoTrait.REORDER},
         skipped=[VideoProbeError(path=tmp_path / "bad.mkv", reason="Invalid data")],
     )
 
     # When: Presenting it
     with pytest.raises(cappa.Exit) as exc_info:
-        present_discovery(report, root=tmp_path, filters={VideoTrait.REORDER}, recursive=False)
+        present_discovery(report, root=tmp_path)
 
     # Then: The error reports the skipped file alongside the mismatch
     error = capsys.readouterr().err
@@ -81,11 +82,11 @@ def test_present_empty_match_reports_skipped_count(capsys, tmp_path):
 def test_present_unfiltered_empty_match_says_unreadable(capsys, tmp_path):
     """Verify an unfiltered run that matched nothing blames readability, not the filters."""
     # Given: A report with candidates, no filters, and no results
-    report = make_report(total=2, filtered=False)
+    report = make_report(total=2)
 
     # When: Presenting it
     with pytest.raises(cappa.Exit) as exc_info:
-        present_discovery(report, root=tmp_path, filters=set(), recursive=False)
+        present_discovery(report, root=tmp_path)
 
     # Then: The error explains that nothing could be read
     assert exc_info.value.code == 1

--- a/tests/test_discovery_output.py
+++ b/tests/test_discovery_output.py
@@ -1,0 +1,89 @@
+# type: ignore
+"""Test the shared discovery presenter."""
+
+import cappa
+import pytest
+
+from vid_cleaner.cli.discovery_output import present_discovery
+from vid_cleaner.constants import SortOrder, VideoTrait
+from vid_cleaner.controllers.discovery import DiscoveryReport
+from vid_cleaner.exceptions import VideoProbeError
+
+
+def make_report(**overrides) -> DiscoveryReport:
+    """Build a DiscoveryReport with test-friendly defaults.
+
+    Returns:
+        DiscoveryReport: A report with every field defaulted unless overridden.
+    """
+    defaults = {
+        "results": [],
+        "total": 0,
+        "skipped": [],
+        "truncated": 0,
+        "sort": SortOrder.ALPHA,
+        "descending": False,
+        "filtered": False,
+    }
+    return DiscoveryReport(**{**defaults, **overrides})
+
+
+def test_present_exits_zero_when_nothing_found(capsys, tmp_path):
+    """Verify an empty directory warns and exits 0, since finding nothing is not an error."""
+    # Given: A report from a directory holding no video files
+    report = make_report(total=0)
+
+    # When: Presenting it
+    with pytest.raises(cappa.Exit) as exc_info:
+        present_discovery(report, root=tmp_path, filters=set(), recursive=False)
+
+    # Then: The command warns and exits successfully
+    assert exc_info.value.code == 0
+    assert "No video files found" in capsys.readouterr().err
+
+
+def test_present_exits_one_when_nothing_matched(capsys, tmp_path):
+    """Verify files found but none matching the filters is an error naming the filters."""
+    # Given: A report where candidates existed but none matched
+    report = make_report(total=3, filtered=True)
+
+    # When: Presenting it with an active filter
+    with pytest.raises(cappa.Exit) as exc_info:
+        present_discovery(report, root=tmp_path, filters={VideoTrait.REORDER}, recursive=False)
+
+    # Then: The command errors and names the unmatched filter
+    assert exc_info.value.code == 1
+    assert "No video files found matching 'reorder'" in capsys.readouterr().err
+
+
+def test_present_empty_match_reports_skipped_count(capsys, tmp_path):
+    """Verify the no-match error folds in the skipped count, since no caption will render."""
+    # Given: A report where every candidate was unreadable
+    report = make_report(
+        total=1,
+        filtered=True,
+        skipped=[VideoProbeError(path=tmp_path / "bad.mkv", reason="Invalid data")],
+    )
+
+    # When: Presenting it
+    with pytest.raises(cappa.Exit) as exc_info:
+        present_discovery(report, root=tmp_path, filters={VideoTrait.REORDER}, recursive=False)
+
+    # Then: The error reports the skipped file alongside the mismatch
+    error = capsys.readouterr().err
+    assert exc_info.value.code == 1
+    assert "1 file(s) skipped as unreadable" in error
+
+
+def test_present_unfiltered_empty_match_says_unreadable(capsys, tmp_path):
+    """Verify an unfiltered run that matched nothing blames readability, not the filters."""
+    # Given: A report with candidates, no filters, and no results
+    report = make_report(total=2, filtered=False)
+
+    # When: Presenting it
+    with pytest.raises(cappa.Exit) as exc_info:
+        present_discovery(report, root=tmp_path, filters=set(), recursive=False)
+
+    # Then: The error explains that nothing could be read
+    assert exc_info.value.code == 1
+    assert "No video files could be read" in capsys.readouterr().err

--- a/tests/test_discovery_output.py
+++ b/tests/test_discovery_output.py
@@ -1,10 +1,12 @@
 # type: ignore
 """Test the shared discovery presenter."""
 
+from pathlib import Path
+
 import cappa
 import pytest
 
-from vid_cleaner.cli.discovery_output import present_discovery
+from vid_cleaner.cli.discovery_output import confirm_selection, present_discovery
 from vid_cleaner.constants import SortOrder, VideoTrait
 from vid_cleaner.controllers.discovery import DiscoveryReport
 from vid_cleaner.exceptions import VideoProbeError
@@ -87,3 +89,112 @@ def test_present_unfiltered_empty_match_says_unreadable(capsys, tmp_path):
     # Then: The error explains that nothing could be read
     assert exc_info.value.code == 1
     assert "No video files could be read" in capsys.readouterr().err
+
+
+def make_result(mocker, name: str, size: int):
+    """Build a stand-in SearchResult carrying only what the prompt reads.
+
+    Returns:
+        MagicMock: An object exposing `.size` and `.video_file.path`.
+    """
+    result = mocker.MagicMock()
+    result.size = size
+    result.video_file.path = Path(f"/media/{name}")
+    return result
+
+
+def test_confirm_returns_when_assume_yes(mocker, capsys):
+    """Verify --yes proceeds without prompting, so unattended runs never block."""
+    # Given: A selection and a stubbed prompt that would fail the test if called
+    report = make_report(results=[make_result(mocker, "a.mkv", 100)], total=1)
+    ask = mocker.patch("vid_cleaner.cli.discovery_output.Confirm.ask")
+
+    # When: Confirming with assume_yes
+    confirm_selection(report, assume_yes=True)
+
+    # Then: No prompt was shown
+    ask.assert_not_called()
+
+
+@pytest.fixture
+def interactive_console(mocker):
+    """Force `Console.is_terminal` so the prompt path can be exercised under pytest.
+
+    Patch the property on the class rather than replacing `pp.console`, which would hand
+    `pp.error` a mock and silently break stderr capture in these same tests.
+
+    Returns:
+        Callable[[bool], None]: Call with True or False to set interactivity.
+    """
+
+    def _inner(is_terminal: bool) -> None:  # noqa: FBT001
+        mocker.patch(
+            "rich.console.Console.is_terminal",
+            new_callable=mocker.PropertyMock,
+            return_value=is_terminal,
+        )
+
+    return _inner
+
+
+def test_confirm_errors_on_non_tty_without_yes(mocker, capsys, interactive_console):
+    """Verify a non-interactive terminal without --yes errors instead of hanging on stdin."""
+    # Given: A non-interactive console
+    report = make_report(results=[make_result(mocker, "a.mkv", 100)], total=1)
+    interactive_console(False)  # noqa: FBT003
+
+    # When: Confirming without assume_yes
+    with pytest.raises(cappa.Exit) as exc_info:
+        confirm_selection(report, assume_yes=False)
+
+    # Then: The command errors and names the flag that would have allowed it
+    assert exc_info.value.code == 1
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_confirm_exits_zero_when_declined(mocker, interactive_console):
+    """Verify declining is a successful no-op, not a failure."""
+    # Given: An interactive console where the user answers no
+    report = make_report(results=[make_result(mocker, "a.mkv", 100)], total=1)
+    interactive_console(True)  # noqa: FBT003
+    mocker.patch("vid_cleaner.cli.discovery_output.Confirm.ask", return_value=False)
+
+    # When: Confirming
+    with pytest.raises(cappa.Exit) as exc_info:
+        confirm_selection(report, assume_yes=False)
+
+    # Then: The command exits successfully without acting
+    assert exc_info.value.code == 0
+
+
+def test_confirm_returns_when_accepted(mocker, interactive_console):
+    """Verify accepting prompts once and lets the caller proceed."""
+    # Given: An interactive console where the user answers yes
+    report = make_report(results=[make_result(mocker, "a.mkv", 100)], total=1)
+    interactive_console(True)  # noqa: FBT003
+    ask = mocker.patch("vid_cleaner.cli.discovery_output.Confirm.ask", return_value=True)
+
+    # When: Confirming
+    confirm_selection(report, assume_yes=False)
+
+    # Then: The user was asked exactly once and the call returned rather than exiting
+    ask.assert_called_once()
+
+
+def test_confirm_prompt_reports_count_and_total_size(mocker, interactive_console):
+    """Verify the prompt states how many files and how many bytes are at stake."""
+    # Given: Two selected files totaling 300 bytes
+    report = make_report(
+        results=[make_result(mocker, "a.mkv", 100), make_result(mocker, "b.mkv", 200)],
+        total=2,
+    )
+    interactive_console(True)  # noqa: FBT003
+    ask = mocker.patch("vid_cleaner.cli.discovery_output.Confirm.ask", return_value=True)
+
+    # When: Confirming
+    confirm_selection(report, assume_yes=False)
+
+    # Then: The prompt names the count and the combined size
+    prompt = ask.call_args.args[0]
+    assert "2 files" in prompt
+    assert "300" in prompt

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,7 +1,6 @@
 # type: ignore
 """Test the search command."""
 
-import copy
 from pathlib import Path
 
 import cappa
@@ -29,42 +28,6 @@ def set_default_settings(tmp_path, mocker, mock_ffprobe_box):
             "drop_original_audio": False,
         }
     )
-
-
-@pytest.fixture
-def search_dir(tmp_path, mocker, mock_ffprobe_box):
-    """Build a directory of video files with per-file size and bitrate.
-
-    Names may include a nested path, e.g. "aaa/mike.mkv", to exercise recursive
-    searches; the parent directory is created automatically.
-
-    Returns:
-        Callable[[list[tuple[str, int, int]]], Path]: Call with `(filename, size_bytes,
-            bitrate_bps)` triples to create the files and patch ffprobe to report the
-            matching bitrate for each one.
-    """
-
-    def _inner(files: list[tuple[str, int, int]]) -> Path:
-        reference = mock_ffprobe_box("reference.json")
-        directory = tmp_path / "library"
-        directory.mkdir(exist_ok=True)
-
-        boxes = {}
-        for name, size, bitrate in files:
-            path = directory / name
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_bytes(b"\0" * size)
-            file_box = copy.deepcopy(reference)
-            file_box.bit_rate = str(bitrate) if bitrate else None
-            boxes[name] = file_box
-
-        mocker.patch(
-            "vid_cleaner.models.video_file.get_probe_as_box",
-            side_effect=lambda path: boxes[path.relative_to(directory).as_posix()],
-        )
-        return directory
-
-    return _inner
 
 
 def test_search_no_video_files(tmp_path, capsys, mocker, debug):
@@ -271,10 +234,10 @@ def test_search_skips_files_that_vanish_before_stat(
         (["--sort", "bitrate", "--reverse"], ["banana", "apple", "cherry"]),
     ],
 )
-def test_search_sort_orders_results(capsys, search_dir, sort_args, expected_order):
+def test_search_sort_orders_results(capsys, video_library, sort_args, expected_order):
     """Verify each sort key and --reverse order the results as documented."""
     # Given: Three files whose alphabetical, size, and bitrate orders all differ
-    directory = search_dir(
+    directory = video_library(
         [
             ("apple.mkv", 100, 2_000_000),
             ("banana.mkv", 300, 1_000_000),
@@ -295,10 +258,10 @@ def test_search_sort_orders_results(capsys, search_dir, sort_args, expected_orde
     assert positions == sorted(positions)
 
 
-def test_search_sort_alpha_uses_full_path(capsys, search_dir):
+def test_search_sort_alpha_uses_full_path(capsys, video_library):
     """Verify alphabetical sorting groups results by directory, not by bare filename."""
     # Given: Files whose directory order and filename order disagree
-    directory = search_dir([("zulu.mkv", 100, 1_000_000), ("aaa/mike.mkv", 100, 1_000_000)])
+    directory = video_library([("zulu.mkv", 100, 1_000_000), ("aaa/mike.mkv", 100, 1_000_000)])
 
     # When: Running a recursive search with the default sort
     args = ["search", str(directory), "--depth", "1", "--filters", "h264"]
@@ -312,10 +275,10 @@ def test_search_sort_alpha_uses_full_path(capsys, search_dir):
     assert output.index("mike") < output.index("zulu")
 
 
-def test_search_table_shows_relative_directory_when_recursive(capsys, search_dir):
+def test_search_table_shows_relative_directory_when_recursive(capsys, video_library):
     """Verify a recursive search renders each result's directory as a dim path segment."""
     # Given: A file nested one directory below the search root
-    directory = search_dir([("zulu.mkv", 100, 1_000_000), ("aaa/mike.mkv", 100, 1_000_000)])
+    directory = video_library([("zulu.mkv", 100, 1_000_000), ("aaa/mike.mkv", 100, 1_000_000)])
 
     # When: Running a recursive search
     args = ["search", str(directory), "--depth", "1", "--filters", "h264"]
@@ -329,10 +292,10 @@ def test_search_table_shows_relative_directory_when_recursive(capsys, search_dir
     assert "aaa/mike.mkv" in output
 
 
-def test_search_table_omits_directory_when_not_recursive(capsys, search_dir):
+def test_search_table_omits_directory_when_not_recursive(capsys, video_library):
     """Verify a depth-0 search renders the bare filename with no directory prefix."""
     # Given: A file at the top level of the search directory
-    directory = search_dir([("mike.mkv", 100, 1_000_000)])
+    directory = video_library([("mike.mkv", 100, 1_000_000)])
 
     # When: Running a non-recursive search (the default depth)
     args = ["search", str(directory), "--filters", "h264"]
@@ -347,10 +310,10 @@ def test_search_table_omits_directory_when_not_recursive(capsys, search_dir):
     assert str(directory) not in output
 
 
-def test_search_sort_bitrate_handles_missing_bitrate(capsys, search_dir):
+def test_search_sort_bitrate_handles_missing_bitrate(capsys, video_library):
     """Verify a file whose probe omits bit_rate sorts last instead of raising."""
     # Given: One file with a bitrate and one without
-    directory = search_dir([("apple.mkv", 100, 0), ("banana.mkv", 100, 5_000_000)])
+    directory = video_library([("apple.mkv", 100, 0), ("banana.mkv", 100, 5_000_000)])
 
     # When: Sorting by bitrate
     args = ["search", str(directory), "--filters", "h264", "--sort", "bitrate"]
@@ -364,14 +327,16 @@ def test_search_sort_bitrate_handles_missing_bitrate(capsys, search_dir):
     assert output.index("banana") < output.index("apple")
 
 
-def test_search_sort_ties_are_deterministic(capsys, search_dir, mocker):
+def test_search_sort_ties_are_deterministic(capsys, video_library, mocker):
     """Verify equal-size files render in a stable order regardless of scan order."""
     # Given: Three files with an identical size, so `--sort=size` cannot break the tie
-    directory = search_dir([("alpha.mkv", 100, 0), ("bravo.mkv", 100, 0), ("charlie.mkv", 100, 0)])
+    directory = video_library(
+        [("alpha.mkv", 100, 0), ("bravo.mkv", 100, 0), ("charlie.mkv", 100, 0)]
+    )
     # find_files' scan order is arbitrary; scramble it here to prove the table's row
     # order does not simply mirror whatever order the filesystem happened to return.
     scrambled = [directory / "bravo.mkv", directory / "charlie.mkv", directory / "alpha.mkv"]
-    mocker.patch("vid_cleaner.cli.search.find_files", return_value=scrambled)
+    mocker.patch("vid_cleaner.controllers.discovery.find_files", return_value=scrambled)
 
     # When: Sorting by size
     args = ["search", str(directory), "--filters", "h264", "--sort", "size"]
@@ -398,10 +363,10 @@ def test_search_rejects_unknown_sort_key(capsys):
     assert exc_info.value.code != 0
 
 
-def test_search_table_shows_size_and_bitrate(capsys, search_dir):
+def test_search_table_shows_size_and_bitrate(capsys, video_library):
     """Verify the results table reports each file's size and bitrate."""
     # Given: A single file with a known size and bitrate
-    directory = search_dir([("apple.mkv", 1500, 2_000_000)])
+    directory = video_library([("apple.mkv", 1500, 2_000_000)])
 
     # When: Running the search command
     args = ["search", str(directory), "--filters", "h264"]
@@ -418,10 +383,10 @@ def test_search_table_shows_size_and_bitrate(capsys, search_dir):
     assert "2.0 Mb/s" in output
 
 
-def test_search_table_marks_the_active_sort_column(capsys, search_dir):
+def test_search_table_marks_the_active_sort_column(capsys, video_library):
     """Verify the sorted column header carries a direction arrow that --reverse flips."""
     # Given: A directory with one matching file
-    directory = search_dir([("apple.mkv", 100, 2_000_000)])
+    directory = video_library([("apple.mkv", 100, 2_000_000)])
 
     # When: Sorting by size
     args = ["search", str(directory), "--filters", "h264", "--sort", "size"]
@@ -439,10 +404,10 @@ def test_search_table_marks_the_active_sort_column(capsys, search_dir):
     assert "Size ↑" in reversed_output
 
 
-def test_search_table_arrow_reports_the_direction_rows_run(capsys, search_dir):
+def test_search_table_arrow_reports_the_direction_rows_run(capsys, video_library):
     """Verify the arrow follows the rendered order, not the --reverse flag."""
     # Given: Two files whose alphabetical order is visible in the table
-    directory = search_dir([("apple.mkv", 100, 2_000_000), ("banana.mkv", 100, 1_000_000)])
+    directory = video_library([("apple.mkv", 100, 2_000_000), ("banana.mkv", 100, 1_000_000)])
 
     # When: Sorting alphabetically, which ascends by default
     args = ["search", str(directory), "--filters", "h264"]
@@ -463,10 +428,10 @@ def test_search_table_arrow_reports_the_direction_rows_run(capsys, search_dir):
     assert reversed_output.index("banana") < reversed_output.index("apple")
 
 
-def test_search_table_caption_reports_counts(capsys, search_dir):
+def test_search_table_caption_reports_counts(capsys, video_library):
     """Verify the caption reports how many files matched out of those scanned."""
     # Given: Two files where only one matches the active filter
-    directory = search_dir([("apple.mkv", 100, 2_000_000), ("banana.mkv", 100, 1_000_000)])
+    directory = video_library([("apple.mkv", 100, 2_000_000), ("banana.mkv", 100, 1_000_000)])
 
     # When: Running a search whose filter matches both
     args = ["search", str(directory), "--filters", "h264"]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -445,6 +445,73 @@ def test_search_table_caption_reports_counts(capsys, video_library):
     assert "2 of 2 files matched" in output
 
 
+def test_search_limit_keeps_top_results(capsys, video_library):
+    """Verify --limit keeps only the top N on the active sort key."""
+    # Given: Three files of differing size
+    directory = video_library(
+        [
+            ("apple.mkv", 100, 1_000_000),
+            ("banana.mkv", 300, 1_000_000),
+            ("cherry.mkv", 200, 1_000_000),
+        ]
+    )
+
+    # When: Asking for the two largest
+    args = ["search", str(directory), "--filters", "h264", "--sort", "size", "--limit", "2"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: Only the two largest render
+    assert exc_info.value.code == 0
+    assert "banana" in output
+    assert "cherry" in output
+    assert "apple" not in output
+
+
+def test_search_limit_caption_reports_truncation(capsys, video_library):
+    """Verify a limited view says so, so it never reads as a complete result set."""
+    # Given: Three matching files
+    directory = video_library(
+        [
+            ("apple.mkv", 100, 1_000_000),
+            ("banana.mkv", 300, 1_000_000),
+            ("cherry.mkv", 200, 1_000_000),
+        ]
+    )
+
+    # When: Limiting to two
+    args = ["search", str(directory), "--filters", "h264", "--sort", "size", "--limit", "2"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The caption distinguishes shown from matched
+    assert exc_info.value.code == 0
+    assert "showing 2" in output
+    assert "3 of 3 files matched" in output
+
+
+def test_search_without_limit_caption_omits_truncation(capsys, video_library):
+    """Verify an unlimited view's caption is unchanged, with no 'showing' prefix."""
+    # Given: Two matching files
+    directory = video_library([("apple.mkv", 100, 1_000_000), ("banana.mkv", 200, 1_000_000)])
+
+    # When: Searching with no limit
+    args = ["search", str(directory), "--filters", "h264"]
+    with pytest.raises(cappa.Exit) as exc_info:
+        cappa.invoke(obj=VidCleaner, argv=args, deps=[config_subcommand])
+
+    output = capsys.readouterr().out
+
+    # Then: The caption reads exactly as it did before --limit existed
+    assert exc_info.value.code == 0
+    assert "2 of 2 files matched" in output
+    assert "showing" not in output
+
+
 def test_search_table_caption_reports_skipped_files(
     capsys, mock_video_path, mocker, mock_ffprobe_box
 ):


### PR DESCRIPTION
Adds `--from DIRECTORY` to `clean`, which selects files by query instead
of by explicit path, using the same `--filters`, `--sort`, `--reverse`,
`--depth`, and `--limit` flags `search` accepts. `clean --from` renders
the selection in the same table `search` prints, then asks for
confirmation before transcoding. Running `search` and `clean --from`
with the same flags selects the same files, so a search is a preview of
the clean that acts on it.

`clean` also processes every file it can rather than stopping at the
first failure, reporting the failures together at the end with a
non-zero exit.

## Changes

- `search` and `clean` share one query vocabulary, including a new
  `--limit N` that keeps the top N results after sorting.
- `--from` is refused alongside explicit paths or `--out`, must name an
  existing directory, and `--limit` must be 1 or greater. The query
  flags and `--yes` are refused without `--from`.
- `--yes` skips the confirmation prompt; `--dryrun` previews without
  prompting. A run with no usable stdin errors rather than hanging on a
  prompt nobody can answer.
- The prompt states whether originals are backed up, because
  `--overwrite` leaves no way back and `--from` can aim it at a library.
- File discovery moved out of `search` into a controller, and a single
  presenter is the only caller of the results table, so the two commands
  cannot drift apart.
- Discovery reuses each file's probe instead of re-running ffprobe, and
  no longer retains every probed file until the process exits.
- `--out`'s help on `clean` and `clip` describes the real default:
  replace the input, keeping a timestamped `.bak`.

## Behavior changes for existing users

- A failing file no longer abandons the rest of a multi-file `clean`.
  Every remaining file is still processed and the failures are listed at
  the end. The exit code is non-zero either way, but more work is done
  than before. `Ctrl-C` still stops the whole run immediately.
- `--out` combined with `--overwrite` no longer deletes the input file.
  It previously removed the source after copying it to the destination,
  contradicting what `--out` documents. `--overwrite` still suppresses
  the backup of whatever it replaces at the destination.
- `clip` no longer turns a failed temp-file cleanup into a traceback
  after the file was written successfully.

## Testing

Full suite green: 270 tests, 93.3% coverage. Verified against the real
CLI that `--from` rejects a missing or non-directory path with a
non-zero exit while a real but empty directory still exits 0, and that
`--out` leaves the input in place with and without `--overwrite`.
